### PR TITLE
Remove authors from the paper until we are ready to add them

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -5,7 +5,6 @@
 \documentclass[12pt]{article}
 
 \title{Delimited effects}
-\author{Stephan Boyer and Esther Wang}
 \date{}
 
 % Add a "Draft" watermark to the background


### PR DESCRIPTION
Remove authors from the paper until we are ready to add them. The first submission needs to be anonymous anyway. I don't like having the authors on the paper right now because it might imply some kind of ordering.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-remove-authors.pdf) is a link to the PDF generated from this PR.
