### PR TITLE
Rename 'Permutation' to 'Exchange'

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -172,7 +172,7 @@
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\cunion{\cextend{\cextend{\ccontext_1}{\tanno{x_1}{\tx_1}}}{\tanno{x_2}{\tx_2}}}{\ccontext_2}}{\eterm}{\tx_3}$}
-        \RightLabel{(\textsc{$\ccontext$-Permutation})}
+        \RightLabel{(\textsc{$\ccontext$-Exchange})}
         \UnaryInfC{$\tjudgment{\cunion{\cextend{\cextend{\ccontext_1}{\tanno{x_2}{\tx_2}}}{\tanno{x_1}{\tx_1}}}{\ccontext_2}}{\eterm}{\tx_3}$}
       \end{prooftree}
 
@@ -190,13 +190,13 @@
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\ccontext}{\eterm}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_1}}{\xeffect_2}}{\xeffects_2}}{\ttype}}$}
-        \RightLabel{(\textsc{$\xeffects$-Permutation1})}
+        \RightLabel{(\textsc{$\xeffects$-Exchange1})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eterm}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_2}}{\xeffect_1}}{\xeffects_2}}{\ttype}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_1}}{\xeffect_2}}{\xeffects_2}}{\ttype}}}}{\eterm}{\tx}$}
-        \RightLabel{(\textsc{$\xeffects$-Permutation2})}
+        \RightLabel{(\textsc{$\xeffects$-Exchange2})}
         \UnaryInfC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_2}}{\xeffect_1}}{\xeffects_2}}{\ttype}}}}{\eterm}{\tx}$}
       \end{prooftree}
 


### PR DESCRIPTION
Rename 'Permutation' to 'Exchange'. I noticed that the rule is called the "exchange" rule in [this Wikipedia article](https://en.wikipedia.org/wiki/Structural_rule). But I also see it called "permutation" in [this other Wikipedia article](https://en.wikipedia.org/wiki/Sequent_calculus). So idk.

Whichever we pick, it should be consistent with the other rules. Our other structural rule is called "Weaken" (a verb), so this rule should be called either "Exchange" or "Permute", but not "Permutation".

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-exchange.pdf) is a link to the PDF generated from this PR.
