### PR TITLE
Add the beginning of an abstract

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -73,6 +73,12 @@
 
   \maketitle
 
+  \begin{abstract}
+    We introduce delimited effects, a modest type and effect system capable of modeling a diverse collection of programming language features including algebraic effects, type classes, and dynamic scoping.
+  \end{abstract}
+
+  \section{Introduction}
+
   \begin{figure}
     \begin{mdframed}
       \begin{center}


### PR DESCRIPTION
Add the beginning of an abstract so the paper can start taking shape. I know it's early, but it helps me to see some words in the document. 😛 

Even though "delimited effects" is written in the abstract, it's still intended to be just a temporary placeholder until we come up with the real name.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-abstract.pdf) is a link to the PDF generated from this PR.
