### PR TITLE
Add Coq compilation step to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 main.pdf
+formalization/*.vo
+formalization/*.vo.aux
+formalization/*.glob

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ main.pdf: main.tex
 	done
 	mv build/main.pdf .
 
+certify:
+	coqc formalization/definitions.v
+
 lint:
 	OUTPUT="$$(lacheck main.tex)"; \
 		if [ -n "$$OUTPUT" ]; \
@@ -27,4 +30,4 @@ lint:
 		fi
 
 clean:
-	rm -rf build main.pdf
+	rm -rf build main.pdf formalization/*.vo formalization/.*.vo.aux formalization/*.glob

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ set -eu -o pipefail
 #   ./deploy.sh
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python-pip texlive-full
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python-pip texlive-full coq
 sudo pip install awscli
 make
 if [ "$TRAVIS_PULL_REQUEST" = 'false' ]; then
@@ -23,3 +23,4 @@ if [ "$TRAVIS_PULL_REQUEST" = 'false' ]; then
   fi
 fi
 make lint
+make certify


### PR DESCRIPTION
Add Coq compilation step to CI. Now the build will fail if the math is wrong!

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-ci-coq.pdf) is a link to the PDF generated from this PR.
