### PR TITLE
Consistently use the custom Coq notation

### DIFF
--- a/formalization/definitions.v
+++ b/formalization/definitions.v
@@ -5,10 +5,12 @@ Require Import Coq.Strings.String.
 Inductive id : Type :=
 | makeId : string -> id.
 
+Notation "'@' s" := (makeId s) (at level 10).
+
 Definition eqId i1 i2 : bool :=
   match i1 with
-    makeId s1 => match i2 with
-      makeId s2 => andb (prefix s1 s2) (prefix s2 s1)
+    @ s1 => match i2 with
+      @ s2 => andb (prefix s1 s2) (prefix s2 s1)
     end
   end.
 
@@ -28,8 +30,7 @@ Inductive term : Type :=
 | eabs : id -> type -> term -> term
 | eapp : term -> term -> term.
 
-Notation "'@' s" := (evar (makeId s)) (at level 10).
-Notation "'λ' s '∈' t '.' e" := (eabs (makeId s) t e) (at level 39).
+Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
 
 (* Contexts *)
 
@@ -37,18 +38,18 @@ Definition context := id -> option type.
 
 Definition emptyContext : context := fun i => None.
 
+Notation "'Ø'" := emptyContext.
+
 Definition extendContext c i1 t : context :=
   fun i2 => if eqId i1 i2 then Some t else c i2.
+
+Notation "c '⊕' i '∈' t" := (extendContext c i t) (at level 39).
 
 Definition lookupVar (c : context) e :=
   match e with
   | evar i => c i
   | _ => None
   end.
-
-Notation "'Ø'" := emptyContext.
-Notation "c ',' s '∈' t" := (extendContext c (makeId s) t) (at level 39).
-Notation "c '[' e ']'" := (lookupVar c e) (at level 40).
 
 (*  Typing rules *)
 
@@ -58,22 +59,22 @@ Inductive hasType : context -> term -> type -> Prop :=
 | aunit : forall c, c ⊢ eunit ∈ tunit
 | avar : forall c e t, lookupVar c e = Some t -> c ⊢ e ∈ t
 | aabs : forall c i t1 t2 e,
-         (extendContext c i t1 ⊢ e ∈ t2) ->
-         (c ⊢ eabs i t1 e ∈ tarrow t1 t2)
+         (c ⊕ i ∈ t1 ⊢ e ∈ t2) ->
+         (c ⊢ λ i ∈ t1 ⇒ e ∈ t1 → t2)
 | aapp : forall c e1 e2 t1 t2,
          c ⊢ e1 ∈ t1 ->
-         c ⊢ e2 ∈ tarrow t1 t2 ->
+         c ⊢ e2 ∈ t1 → t2 ->
          c ⊢ eapp e2 e1 ∈ t2
 where "c '⊢' e '∈' t" := (hasType c e t).
 
-(* An example proof *)
+(* Example proofs *)
 
-Definition v_unit := eunit.
+Definition ex1 := eunit.
 
-Theorem v_tunit : emptyContext ⊢ v_unit ∈ tunit.
+Theorem ex1WellTyped : Ø ⊢ ex1 ∈ tunit.
 Proof. apply aunit. Qed.
 
-Definition v_id := eabs (makeId "x") tunit (evar (makeId "x")).
+Definition ex2 := λ @ "x" ∈ tunit ⇒ evar (@ "x").
 
-Theorem v_tid : emptyContext ⊢ v_id ∈ tarrow tunit tunit.
+Theorem ex2WellTyped : Ø ⊢ ex2 ∈ tunit → tunit.
 Proof. apply aabs. apply avar. simpl. reflexivity. Qed.


### PR DESCRIPTION
Consistently use the custom Coq notation. Now the custom notation is used everywhere.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-coq-notation.pdf) is a link to the PDF generated from this PR.
