### PR TITLE
Formalize context with a datatype

### DIFF
--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -34,19 +34,18 @@ Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
 
 (* Contexts *)
 
-Definition context := id -> option type.
+Inductive context : Type :=
+| cempty : context
+| cextend : context -> id -> type -> context.
 
-Definition emptyContext : context := fun i => None.
+Notation "'Ø'" := cempty.
+Notation "c ',' i '∈' t" := (cextend c i t) (at level 39).
 
-Notation "'Ø'" := emptyContext.
-
-Definition extendContext c i1 t : context :=
-  fun i2 => if eqId i1 i2 then Some t else c i2.
-
-Notation "c '⊕' i '∈' t" := (extendContext c i t) (at level 39).
-
-Definition lookupVar (c : context) e :=
+Fixpoint lookupVar (c1 : context) e :=
   match e with
-  | evar i => c i
+  | evar i1 => match c1 with
+               | cempty => None
+               | cextend c2 i2 t => if eqId i1 i2 then Some t else lookupVar c2 e
+               end
   | _ => None
   end.

--- a/formalization/typingRules.v
+++ b/formalization/typingRules.v
@@ -6,7 +6,7 @@ Inductive hasType : context -> term -> type -> Prop :=
 | aunit : forall c, c ⊢ eunit ∈ tunit
 | avar : forall c e t, lookupVar c e = Some t -> c ⊢ e ∈ t
 | aabs : forall c i t1 t2 e,
-         c ⊕ i ∈ t1 ⊢ e ∈ t2 ->
+         c , i ∈ t1 ⊢ e ∈ t2 ->
          c ⊢ λ i ∈ t1 ⇒ e ∈ t1 → t2
 | aapp : forall c e1 e2 t1 t2,
          c ⊢ e1 ∈ t1 ->


### PR DESCRIPTION
If you prefer, we can keep oplus as the symbol for extending a context.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-datatype-for-context.pdf) is a link to the PDF generated from this PR.
