### PR TITLE
Formalize our syntax in coq

### DIFF
--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -1,3 +1,4 @@
+Require Import Coq.Lists.List.
 Require Import Coq.Strings.String.
 
 (* Identifiers *)
@@ -5,22 +6,14 @@ Require Import Coq.Strings.String.
 Inductive id : Type :=
 | makeId : string -> id.
 
-Notation "'@' s" := (makeId s) (at level 10).
-
-Definition eqId i1 i2 : bool :=
-  match i1 with
-  | @ s1 => match i2 with
-    | @ s2 => andb (prefix s1 s2) (prefix s2 s1)
-    end
-  end.
-
 (* Types *)
 
 Inductive type : Type :=
+| tvar : id -> type
 | tunit : type
-| tarrow : type -> type -> type.
-
-Notation "t1 '→' t2" := (tarrow t1 t2) (at level 38).
+| tarrow : type -> type -> type
+| ttforall : id -> type -> type
+| txforall : id -> type -> type.
 
 (* Terms *)
 
@@ -28,18 +21,45 @@ Inductive term : Type :=
 | eunit : term
 | evar : id -> term
 | eabs : id -> type -> term -> term
-| eapp : term -> term -> term.
+| eapp : term -> term -> term
+| etabs : id -> term -> term
+| etapp : term -> type -> term
+| exabs : id -> term -> term
+| exapp : term -> effects -> term
+| eeffect : id -> list id -> id -> type -> term -> term
+| eprovide : id -> list type -> effects -> id -> term -> term -> term
 
-Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
+(* Effects *)
 
-(* Contexts *)
+with effects : Type :=
+| xvar : id -> effects
+| xempty : effects
+| xsingleton : id -> list type -> effects
+| xunion : effects -> effects.
+
+(* Type contexts *)
 
 Inductive context : Type :=
 | cempty : context
 | cextend : context -> id -> type -> context.
 
+(* Effect context *)
+Inductive xContext : Type :=
+| dempty : xContext
+| dextend : xContext -> id -> list id -> id -> type -> xContext.
+
+Notation "'@' s" := (makeId s) (at level 10).
+Notation "t1 '→' t2" := (tarrow t1 t2) (at level 38).
+Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
 Notation "'Ø'" := cempty.
 Notation "c ',' i '∈' t" := (cextend c i t) (at level 39).
+
+Definition eqId i1 i2 : bool :=
+  match i1 with
+  | @ s1 => match i2 with
+    | @ s2 => andb (prefix s1 s2) (prefix s2 s1)
+    end
+  end.
 
 Fixpoint lookupVar (c1 : context) e :=
   match e with


### PR DESCRIPTION
I added our syntax to the coq formalization and moved notation and definition statements to the bottom of the syntax file. Todo: define the notation for the new syntax.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-formalize-syntax-coq.pdf) is a link to the PDF generated from this PR.
