### PR TITLE
[coq] Add phantom types to ids

### DIFF
--- a/formalization/examples.v
+++ b/formalization/examples.v
@@ -6,7 +6,7 @@ Definition ex1 := eunit.
 Theorem ex1WellTyped : Ø ⊢ ex1 ∈ tunit.
 Proof. apply aunit. Qed.
 
-Definition ex2 := λ @ "x" ∈ tunit ⇒ evar (@ "x").
+Definition ex2 := λ (makeId eid "x") ∈ tunit ⇒ evar (makeId eid "x").
 
 Theorem ex2WellTyped : Ø ⊢ ex2 ∈ tunit → tunit.
 Proof. apply aabs. apply avar. reflexivity. Qed.

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -8,8 +8,8 @@ Inductive id (T : Type) : Type :=
 
 Inductive tid : Type := . (* Type id *)
 Inductive eid : Type := . (* Term id *)
-Inductive xid : Type := . (* Effect row id *)
-Inductive fid : Type := . (* Effect id *)
+Inductive rid : Type := . (* Effect row id *)
+Inductive xid : Type := . (* Effect id *)
 
 (* Types *)
 
@@ -18,7 +18,7 @@ Inductive type : Type :=
 | tunit : type
 | tarrow : type -> type -> type
 | ttforall : id tid -> type -> type
-| txforall : id xid -> type -> type.
+| txforall : id rid -> type -> type.
 
 (* Terms *)
 
@@ -29,17 +29,17 @@ Inductive term : Type :=
 | eapp : term -> term -> term
 | etabs : id tid -> term -> term
 | etapp : term -> type -> term
-| exabs : id xid -> term -> term
+| exabs : id rid -> term -> term
 | exapp : term -> effects -> term
-| eeffect : id fid -> list (id tid) -> id eid -> type -> term -> term
-| eprovide : id fid -> list type -> effects -> id eid -> term -> term -> term
+| eeffect : id xid -> list (id tid) -> id eid -> type -> term -> term
+| eprovide : id xid -> list type -> effects -> id eid -> term -> term -> term
 
 (* Effects *)
 
 with effects : Type :=
-| xvar : id xid -> effects
+| xvar : id rid -> effects
 | xempty : effects
-| xsingleton : id fid -> list type -> effects
+| xsingleton : id xid -> list type -> effects
 | xunion : effects -> effects.
 
 (* Type contexts *)
@@ -52,7 +52,7 @@ Inductive context : Type :=
 
 Inductive xContext : Type :=
 | dempty : xContext
-| dextend : xContext -> id fid -> list (id tid) -> id eid -> type -> xContext.
+| dextend : xContext -> id xid -> list (id tid) -> id eid -> type -> xContext.
 
 (* Notation "'@'" := makeId (at level 10). *)
 Notation "t1 '→' t2" := (tarrow t1 t2) (at level 38).
@@ -60,18 +60,18 @@ Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
 Notation "'Ø'" := cempty.
 Notation "c ',' i '∈' t" := (cextend c i t) (at level 39).
 
-Definition eqId (X : Set) (i1 : id X) (i2 : id X) : bool :=
+Definition eqId {X : Set} (i1 : id X) (i2 : id X) : bool :=
   match i1 with
   | makeId _ s1 => match i2 with
     | makeId _ s2 => andb (prefix s1 s2) (prefix s2 s1)
-     end
+    end
   end.
 
 Fixpoint lookupVar (c1 : context) e :=
   match e with
   | evar i1 => match c1 with
                | cempty => None
-               | cextend c2 i2 t => if eqId eid i1 i2 then Some t else lookupVar c2 e
-              end
+               | cextend c2 i2 t => if eqId i1 i2 then Some t else lookupVar c2 e
+               end
   | _ => None
   end.

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -3,69 +3,75 @@ Require Import Coq.Strings.String.
 
 (* Identifiers *)
 
-Inductive id : Type :=
-| makeId : string -> id.
+Inductive id (T : Type) : Type :=
+| makeId : string -> id T.
+
+Inductive tid : Type := . (* Type id *)
+Inductive eid : Type := . (* Term id *)
+Inductive xid : Type := . (* Effect row id *)
+Inductive fid : Type := . (* Effect id *)
 
 (* Types *)
 
 Inductive type : Type :=
-| tvar : id -> type
+| tvar : id tid -> type
 | tunit : type
 | tarrow : type -> type -> type
-| ttforall : id -> type -> type
-| txforall : id -> type -> type.
+| ttforall : id tid -> type -> type
+| txforall : id xid -> type -> type.
 
 (* Terms *)
 
 Inductive term : Type :=
 | eunit : term
-| evar : id -> term
-| eabs : id -> type -> term -> term
+| evar : id eid -> term
+| eabs : id eid -> type -> term -> term
 | eapp : term -> term -> term
-| etabs : id -> term -> term
+| etabs : id tid -> term -> term
 | etapp : term -> type -> term
-| exabs : id -> term -> term
+| exabs : id xid -> term -> term
 | exapp : term -> effects -> term
-| eeffect : id -> list id -> id -> type -> term -> term
-| eprovide : id -> list type -> effects -> id -> term -> term -> term
+| eeffect : id fid -> list (id tid) -> id eid -> type -> term -> term
+| eprovide : id fid -> list type -> effects -> id eid -> term -> term -> term
 
 (* Effects *)
 
 with effects : Type :=
-| xvar : id -> effects
+| xvar : id xid -> effects
 | xempty : effects
-| xsingleton : id -> list type -> effects
+| xsingleton : id fid -> list type -> effects
 | xunion : effects -> effects.
 
 (* Type contexts *)
 
 Inductive context : Type :=
 | cempty : context
-| cextend : context -> id -> type -> context.
+| cextend : context -> id eid -> type -> context.
 
 (* Effect context *)
+
 Inductive xContext : Type :=
 | dempty : xContext
-| dextend : xContext -> id -> list id -> id -> type -> xContext.
+| dextend : xContext -> id fid -> list (id tid) -> id eid -> type -> xContext.
 
-Notation "'@' s" := (makeId s) (at level 10).
+(* Notation "'@'" := makeId (at level 10). *)
 Notation "t1 '→' t2" := (tarrow t1 t2) (at level 38).
 Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
 Notation "'Ø'" := cempty.
 Notation "c ',' i '∈' t" := (cextend c i t) (at level 39).
 
-Definition eqId i1 i2 : bool :=
+Definition eqId (X : Set) (i1 : id X) (i2 : id X) : bool :=
   match i1 with
-  | @ s1 => match i2 with
-    | @ s2 => andb (prefix s1 s2) (prefix s2 s1)
-    end
+  | makeId _ s1 => match i2 with
+    | makeId _ s2 => andb (prefix s1 s2) (prefix s2 s1)
+     end
   end.
 
 Fixpoint lookupVar (c1 : context) e :=
   match e with
   | evar i1 => match c1 with
                | cempty => None
-               | cextend c2 i2 t => if eqId i1 i2 then Some t else lookupVar c2 e
-               end
+               | cextend c2 i2 t => if eqId eid i1 i2 then Some t else lookupVar c2 e
+              end
   | _ => None
   end.

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -11,48 +11,54 @@ Inductive eid : Type := . (* Term id *)
 Inductive rid : Type := . (* Effect row id *)
 Inductive xid : Type := . (* Effect id *)
 
+Definition typeId := id tid.
+Definition termId := id eid.
+Definition effectRowId := id rid.
+Definition effectId := id xid.
+
+
 (* Types *)
 
 Inductive type : Type :=
-| tvar : id tid -> type
+| tvar : typeId -> type
 | tunit : type
 | tarrow : type -> type -> type
-| ttforall : id tid -> type -> type
-| txforall : id rid -> type -> type.
+| ttforall : typeId -> type -> type
+| txforall : effectRowId -> type -> type.
 
 (* Terms *)
 
 Inductive term : Type :=
 | eunit : term
-| evar : id eid -> term
-| eabs : id eid -> type -> term -> term
+| evar : termId -> term
+| eabs : termId -> type -> term -> term
 | eapp : term -> term -> term
-| etabs : id tid -> term -> term
+| etabs : typeId -> term -> term
 | etapp : term -> type -> term
-| exabs : id rid -> term -> term
+| exabs : effectRowId -> term -> term
 | exapp : term -> effects -> term
-| eeffect : id xid -> list (id tid) -> id eid -> type -> term -> term
-| eprovide : id xid -> list type -> effects -> id eid -> term -> term -> term
+| eeffect : effectId -> list (typeId) -> termId -> type -> term -> term
+| eprovide : effectId -> list type -> effects -> termId -> term -> term -> term
 
 (* Effects *)
 
 with effects : Type :=
-| xvar : id rid -> effects
+| xvar : effectRowId -> effects
 | xempty : effects
-| xsingleton : id xid -> list type -> effects
+| xsingleton : effectId -> list type -> effects
 | xunion : effects -> effects.
 
 (* Type contexts *)
 
 Inductive context : Type :=
 | cempty : context
-| cextend : context -> id eid -> type -> context.
+| cextend : context -> termId -> type -> context.
 
 (* Effect context *)
 
 Inductive xContext : Type :=
 | dempty : xContext
-| dextend : xContext -> id xid -> list (id tid) -> id eid -> type -> xContext.
+| dextend : xContext -> effectId -> list (typeId) -> termId -> type -> xContext.
 
 (* Notation "'@'" := makeId (at level 10). *)
 Notation "t1 '→' t2" := (tarrow t1 t2) (at level 38).


### PR DESCRIPTION
Parameterize the types of ids with phantom types in order to differentiate between each type of id (effect variable, type variable, etc).

I tried to get the `@` notation to work, but couldn't. It's commented out for now and I'm using `makeId` directly.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-phantom-types.pdf) is a link to the PDF generated from this PR.
