### PR TITLE
Download the coqc binary from S3

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,10 +11,21 @@ set -eu -o pipefail
 #   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
 #   ./deploy.sh
 
+# Install LaTeX and the AWS CLI
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python-pip texlive-full coq
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python-pip texlive-full
 sudo pip install awscli
+
+# Install Coq
+curl -o /tmp/coq-8.6.tar.gz https://s3.amazonaws.com/stephan-misc/paper/coq-8.6.tar.gz
+tar -xzf /tmp/coq-8.6.tar.gz -C /tmp
+cd /tmp/coq-8.6 && sudo make install && cd -
+rm -rf /tmp/coq-8.6
+
+# Build the PDF, check the Coq scripts, and lint the source
 make
+
+# Upload the PDF to S3
 if [ "$TRAVIS_PULL_REQUEST" = 'false' ]; then
   if [ "$TRAVIS_BRANCH" = 'master' ]; then
     aws s3 cp --acl public-read main.pdf 's3://stephan-misc/paper/latest.pdf'


### PR DESCRIPTION
Download the `coqc` binary from S3 instead of installing it with `apt-get`. This allows us to use Coq 8.6 instead of 8.4.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-coqc.pdf) is a link to the PDF generated from this PR.
