### PR TITLE
Fix well-formedness rules and T-Effect

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -268,6 +268,18 @@
         \UnaryInfC{$\xopwellformed{\sscheme_1}{\stwithx{\parens{\tarrow{\sscheme_3}{\sscheme_2}}}{\rrow}}$}
       \end{prooftree}
 
+      \begin{prooftree}
+          \AxiomC{$\xopwellformed{\sscheme_1}{\sscheme_2}$}
+        \RightLabel{(\textsc{WF-ForAll})}
+        \UnaryInfC{$\xopwellformed{\sscheme_1}{\stwithx{\parens{\ttforall{\anno{\svar}{\kkind}}{\sscheme_2}}}{\rrow}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{$\rorder{\rsingleton{\sscheme}}{\rrow}$}
+        \RightLabel{(\textsc{WF-TypeWithEffects})}
+        \UnaryInfC{$\xopwellformed{\sscheme}{\stwithx{\ttype}{\rrow}}$}
+      \end{prooftree}
+
       \caption{Operation type well-formedness}\label{fig:operation_type}
     \end{mdframed}
   \end{figure}
@@ -324,13 +336,14 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\cextend{\cextend{\ccontext}{\anno{\svar_1}{\karrow{\lstof{\anno{\svar_2^i}{\kkind^i}}}{\keffect{\evar}{\sscheme_1}}}}}{\anno{\evar}{\sscheme_1}}}{\eterm}{\sscheme_2}$}
-          \AxiomC{$\xopwellformed{\svar_1}{\sscheme_1}$}
-          \AxiomC{$\svar_1 \notin \sscheme_2$}
-          \AxiomC{$\svar_1 \notin \dom{\ccontext}$}
-          \AxiomC{$\evar \notin \dom{\ccontext}$}
+          \AxiomC{\Shortstack[c]{{$\anno{\sscheme_1}{\ktype}$}
+            {$\xopwellformed{\sapp{\svar_1}{\lstof{\svar_2^i}}}{\sscheme_1}$}
+            {$\svar_1 \notin \sscheme_2$}
+            {$\svar_1 \notin \dom{\ccontext}$}
+            {$\evar \notin \dom{\ccontext}$}
+            {$\tjudgment{\cextend{\cextend{\ccontext}{\anno{\svar_1}{\karrow{\lstof{\anno{\svar_2^i}{\kkind^i}}}{\keffect{\evar}{\sscheme_1}}}}}{\anno{\evar}{\sscheme_1}}}{\eterm}{\sscheme_2}$}}}
         \RightLabel{(\textsc{T-Effect})}
-        \QuinaryInfC{$\tjudgment{\ccontext}{\parens{\eeffect{\svar_1}{\lstof{\anno{\svar_2^i}{\kkind^i}}}{\evar}{\sscheme_1}{\eterm}}}{\sscheme_2}$}
+        \UnaryInfC{$\tjudgment{\ccontext}{\parens{\eeffect{\svar_1}{\lstof{\anno{\svar_2^i}{\kkind^i}}}{\evar}{\sscheme_1}{\eterm}}}{\sscheme_2}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
Update the well-formedness rule to work with schemes. Also add a check to the effect rule to make sure that the type of the operation has kind `*`.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-fix-well-formed.pdf) is a link to the PDF generated from this PR.
