### PR TITLE
Use a less misleading syntax for term application

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -42,8 +42,8 @@
 \newcommand\eterm{t}
 \newcommand\evar{x}
 \newcommand\eabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
-\newcommand\eappbv[2]{#1 \left\llbracket #2 \right\rrbracket_{\textsc{V}}} % chktex 1
-\newcommand\eappbn[2]{#1 \left\llbracket #2 \right\rrbracket_{\textsc{N}}} % chktex 1
+\newcommand\eappbv[2]{#1 \; \$ \; #2}
+\newcommand\eappbn[2]{#1 \; @ \; #2}
 \newcommand\esabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
 \newcommand\esapp[2]{#1 \; #2}
 \newcommand\eeffect[3]{\textbf{effect} \; \anno{#1}{#2} \; \textbf{in} \; #3}


### PR DESCRIPTION
Use a less misleading syntax for term application to avoid confusion with denotation syntax.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-application-syntax.pdf) is a link to the PDF generated from this PR.
