### PR TITLE
Set up Docker build infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # NOTE: If you change this file, you probably
-#       also want to change .dockerignore.
+#       also want to change .gitignore.
 
 main.pdf
 paper-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ os: linux
 dist: trusty
 language: generic
 sudo: required
+services: docker
 script: ./deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Phony targets
 
-.PHONY: all paper lint formalization clean clean-paper clean-formalization
+.PHONY: all paper lint formalization clean clean-paper clean-formalization docker-deps docker-build
 
 all: paper lint formalization
 
@@ -29,6 +29,12 @@ clean-paper:
 
 clean-formalization:
 	rm -rf paper-build formalization/*.vo formalization/.*.vo.aux formalization/*.glob
+
+docker-deps:
+	docker build -f docker/Dockerfile-deps -t stephanmisc/delimited-effects:deps .
+
+docker-build:
+	docker build -f docker/Dockerfile-build -t stephanmisc/delimited-effects:build .
 
 # The paper
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,30 +6,32 @@ set -eu -o pipefail
 
 # Usage:
 #   TRAVIS_BRANCH=master \
+#   TRAVIS_PULL_REQUEST=false \
 #   AWS_DEFAULT_REGION=us-east-1 \
 #   AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
 #   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
 #   ./deploy.sh
 
-# Install LaTeX and the AWS CLI
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python-pip texlive-full
-sudo pip install awscli
+# Build the PDF, check the Coq scripts, and lint the source.
+make docker-build
 
-# Install Coq
-curl -o /tmp/coq-8.6.tar.gz https://s3.amazonaws.com/stephan-misc/paper/coq-8.6.tar.gz
-tar -xzf /tmp/coq-8.6.tar.gz -C /tmp
-cd /tmp/coq-8.6 && sudo make install && cd -
-rm -rf /tmp/coq-8.6
-
-# Build the PDF, check the Coq scripts, and lint the source
-make
-
-# Upload the PDF to S3
+# Upload the PDF to S3.
 if [ "$TRAVIS_PULL_REQUEST" = 'false' ]; then
   if [ "$TRAVIS_BRANCH" = 'master' ]; then
-    aws s3 cp --acl public-read main.pdf 's3://stephan-misc/paper/latest.pdf'
+    docker run \
+      -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
+      -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+      -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+      -it stephanmisc/delimited-effects:build aws s3 cp --acl public-read \
+      /root/delimited-effects/main.pdf \
+      s3://stephan-misc/paper/latest.pdf
   else
-    aws s3 cp --acl public-read main.pdf "s3://stephan-misc/paper/branch-$TRAVIS_BRANCH.pdf"
+    docker run \
+      -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
+      -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+      -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+      -it stephanmisc/delimited-effects:build aws s3 cp --acl public-read \
+      /root/delimited-effects/main.pdf \
+      "s3://stephan-misc/paper/branch-$TRAVIS_BRANCH.pdf"
   fi
 fi

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -1,0 +1,3 @@
+FROM stephanmisc/delimited-effects:deps
+COPY . /root/delimited-effects
+RUN cd /root/delimited-effects && make

--- a/docker/Dockerfile-deps
+++ b/docker/Dockerfile-deps
@@ -1,0 +1,25 @@
+FROM debian:stretch
+RUN \
+  # Update package lists.
+  DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+
+  # Install various packages.
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    # Coq
+    coq \
+
+    # For installing the AWS CLI below
+    python-pip \
+
+    # LaTeX
+    texlive-full && \
+
+  # Now that the packages are installed, free up some space by removing the
+  # package lists.
+  rm -rf /var/lib/apt/lists/* && \
+
+  # Install the AWS CLI.
+  pip install awscli && \
+
+  # Free up 2G of disk space.
+  rm -rf /usr/share/doc


### PR DESCRIPTION
Set up Docker build infrastructure for building the PDF, typechecking the Coq scripts, and linting. This will reduce the build time by approximately 1m.

Unfortunately, builds are still pretty slow (~6m) due to the time spent downloading the Docker image (3 GB!). But at least this gives us the option of optimizing the Docker image later.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-docker.pdf) is a link to the PDF generated from this PR.
