### PR TITLE
Put termId before schemeId

### DIFF
--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -6,11 +6,11 @@ Require Import Coq.Strings.String.
 Inductive id (T : Type) : Type :=
 | makeId : string -> id T.
 
-Inductive sid : Type := . (* Scheme id *)
 Inductive eid : Type := . (* Term id *)
+Inductive sid : Type := . (* Scheme id *)
 
-Definition schemeId := id sid.
 Definition termId := id eid.
+Definition schemeId := id sid.
 
 (* Terms *)
 


### PR DESCRIPTION
Put `termId` before `schemeId` (and likewise for `eid` and `sid`). I think this order makes more sense. I can't remember why we had it the other way before.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-reorder-ids.pdf) is a link to the PDF generated from this PR.
