### PR TITLE
Finish the rules for effect row subsumption

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -6,7 +6,45 @@ Inductive subsumes : row -> row -> Prop :=
 | rsRefl :
     forall r,
     subsumes r r
-(* TODO: Fill in the other rules here. *)
+| rsTrans :
+    forall r1 r2 r3,
+    subsumes r1 r2 ->
+    subsumes r2 r3 ->
+    subsumes r1 r3
+| rsSub :
+    forall r1 r2 r3,
+    subsumes r1 r2 ->
+    subsumes (runion r1 r3) (runion r2 r3)
+| rsLeftAssoc:
+    forall r1 r2 r3,
+    subsumes (runion r1 r2) r3 ->
+    subsumes r1 (runion r2 r3)
+| rsRightAssoc:
+    forall r1 r2 r3,
+    subsumes r1 (runion r2 r3) ->
+    subsumes (runion r1 r2) r3
+| rsLeftContract:
+    forall r1,
+    subsumes (runion r1 r1) r1
+| rsRightContract:
+    forall r1,
+    subsumes r1 (runion r1 r1)
+| rsWeaken :
+    forall r1 r2,
+    subsumes r1 (runion r1 r2)
+| rsLeftId:
+    forall r1,
+    subsumes (runion rempty r1) r1
+| rsRightId:
+    forall r1,
+    subsumes r1 (runion rempty r1)
+| rsExchange :
+    forall r1 r2,
+    subsumes (runion r1 r2) (runion r2 r1)
+| rsSchemeEq :
+    forall s1 s2,
+    schemeEq s1 s2 ->
+    subsumes (rsingleton s1) (rsingleton s2)
 
 (* Subtyping *)
 

--- a/main.tex
+++ b/main.tex
@@ -171,6 +171,12 @@
       \end{prooftree}
 
       \begin{prooftree}
+          \AxiomC{$\rorder{\row_1}{\row_2}$}
+        \RightLabel{(\textsc{E-Subsumption})}
+        \UnaryInfC{$\rorder{\runion{\row_1}{\row_3}}{\runion{\row_2}{\row_3}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{E-LeftAssociativity})}
         \UnaryInfC{$\rorder{\runion{\parens{\runion{\row_1}{\row_2}}}{\row_3}}{\runion{\row_1}{\parens{\runion{\row_2}{\row_3}}}}$}
@@ -180,6 +186,30 @@
           \AxiomC{}
         \RightLabel{(\textsc{E-RightAssociativity})}
         \UnaryInfC{$\rorder{\runion{\row_1}{\parens{\runion{\row_2}{\row_3}}}}{\runion{\parens{\runion{\row_1}{\row_2}}}{\row_3}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{E-LeftContraction})}
+        \UnaryInfC{$\rorder{\runion{\row}{\row}}{\row}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{E-RightContraction})}
+        \UnaryInfC{$\rorder{\row}{\runion{\row}{\row}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{E-Weakening})}
+        \UnaryInfC{$\rorder{\row_1}{\runion{\row_1}{\row_2}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{E-Exchange})}
+        \UnaryInfC{$\rorder{\runion{\row_1}{\row_2}}{\runion{\row_2}{\row_1}}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -195,33 +225,9 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-LeftContraction})}
-        \UnaryInfC{$\rorder{\runion{\runion{\row}{\rsingleton{\scheme}}}{\rsingleton{\scheme}}}{\runion{\row}{\rsingleton{\scheme}}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-RightContraction})}
-        \UnaryInfC{$\rorder{\runion{\row}{\rsingleton{\scheme}}}{\runion{\runion{\row}{\rsingleton{\scheme}}}{\rsingleton{\scheme}}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-Weakening})}
-        \UnaryInfC{$\rorder{\row}{\runion{\row}{\rsingleton{\scheme}}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-Exchange})}
-        \UnaryInfC{$\rorder{\runion{\runion{\runion{\row_1}{\rsingleton{\scheme_1}}}{\rsingleton{\scheme_2}}}{\row_2}}{\runion{\runion{\runion{\row_1}{\rsingleton{\scheme_2}}}{\rsingleton{\scheme_1}}}{\row_2}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
           \AxiomC{$\sequiv{\scheme_1}{\scheme_2}$}
         \RightLabel{(\textsc{E-SchemeEquivalence})}
-        \UnaryInfC{$\rorder{\runion{\row}{\rsingleton{\scheme_1}}}{\runion{\row}{\rsingleton{\scheme_2}}}$}
+        \UnaryInfC{$\rorder{\rsingleton{\scheme_1}}{\rsingleton{\scheme_2}}$}
       \end{prooftree}
 
       \caption{Effect row subsumption}\label{fig:preorder}


### PR DESCRIPTION
Several of the rules in the paper were incorrect. This PR fixes them (to the best of my knowledge) and formalizes them in Coq. Later we will prove that these rules capture "set-like" behavior.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-effect-row-subsumption.pdf) is a link to the PDF generated from this PR.
