### PR TITLE
Formalize in Coq the correctness proposition for effect row subsumption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 			else echo "No ChkTeX errors."; \
 		fi
 
-formalization: $(addprefix formalization/, syntax.vo judgments.vo)
+formalization: $(addprefix formalization/, syntax.vo judgments.vo subsumption.vo)
 
 clean: clean-paper clean-formalization
 
@@ -57,3 +57,6 @@ formalization/syntax.vo: formalization/syntax.v
 
 formalization/judgments.vo: $(addprefix formalization/, syntax.vo judgments.v)
 	COQPATH="$$(pwd)/formalization" coqc formalization/judgments.v
+
+formalization/subsumption.vo: $(addprefix formalization/, syntax.vo judgments.vo subsumption.v)
+	COQPATH="$$(pwd)/formalization" coqc formalization/subsumption.v

--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -11,36 +11,26 @@ Inductive subsumes : row -> row -> Prop :=
     subsumes r1 r2 ->
     subsumes r2 r3 ->
     subsumes r1 r3
-| rsSub :
-    forall r1 r2 r3,
-    subsumes r1 r2 ->
-    subsumes (runion r1 r3) (runion r2 r3)
-| rsLeftAssoc:
-    forall r1 r2 r3,
-    subsumes (runion r1 r2) r3 ->
-    subsumes r1 (runion r2 r3)
-| rsRightAssoc:
-    forall r1 r2 r3,
-    subsumes r1 (runion r2 r3) ->
-    subsumes (runion r1 r2) r3
-| rsLeftContract:
+| rsContract:
     forall r1,
     subsumes (runion r1 r1) r1
-| rsRightContract:
-    forall r1,
-    subsumes r1 (runion r1 r1)
 | rsWeaken :
     forall r1 r2,
     subsumes r1 (runion r1 r2)
-| rsLeftId:
-    forall r1,
-    subsumes (runion rempty r1) r1
-| rsRightId:
-    forall r1,
-    subsumes r1 (runion rempty r1)
 | rsExchange :
     forall r1 r2,
     subsumes (runion r1 r2) (runion r2 r1)
+| rsSub :		
+    forall r1 r2 r3,		
+    subsumes r1 r2 ->		
+    subsumes (runion r1 r3) (runion r2 r3)
+| rsId:
+    forall r1,
+    subsumes rempty r1
+| rsAssoc:
+    forall r1 r2 r3,
+    subsumes (runion r1 r2) r3 ->
+    subsumes r1 (runion r2 r3)
 | rsSchemeEq :
     forall s1 s2,
     schemeEq s1 s2 ->
@@ -87,14 +77,14 @@ with hasKind : context -> scheme -> kind -> Prop :=
 
 with schemeEq : scheme -> scheme -> Prop :=
 | seRefl :
-    forall a b,
-    schemeEq a b
+    forall s,
+    schemeEq s s
 (* TODO: Fill in the other rules here. *)
 
 (* Kind equivalence *)
 
 with kindEq : kind -> kind -> Prop :=
 | keRefl :
-    forall a b,
-    kindEq a b.
+    forall k,
+    kindEq k k.
 (* TODO: Fill in the other rules here. *)

--- a/formalization/subsumption.v
+++ b/formalization/subsumption.v
@@ -1,0 +1,49 @@
+Require Import syntax.
+Require Import judgments.
+
+Inductive rowContains : row -> scheme -> Prop :=
+| rcSingleton :
+    forall s,
+    rowContains (rsingleton s) s
+| rcUnionLeft :
+    forall r1 r2 s,
+    rowContains r1 s ->
+    rowContains (runion r1 r2) s
+| rcUnionRight :
+    forall r1 r2 s,
+    rowContains r2 s ->
+    rowContains (runion r1 r2) s.
+
+Lemma containmentImpliesSubsumption :
+  forall r1 r2, (
+    forall s1,
+    rowContains r1 s1 ->
+    exists s2,
+    (schemeEq s1 s2 /\ rowContains r2 s2)
+  ) ->
+  subsumes r1 r2.
+Admitted.
+
+Lemma subsumptionImpliesContainment :
+  forall r1 r2,
+  subsumes r1 r2 -> (
+    forall s1,
+    rowContains r1 s1 ->
+    exists s2,
+    (schemeEq s1 s2 /\ rowContains r2 s2)
+  ).
+Admitted.
+
+Theorem subsumptionCorrect :
+  forall r1 r2, (
+    forall s1,
+    rowContains r1 s1 ->
+    exists s2,
+    (schemeEq s1 s2 /\ rowContains r2 s2)
+  ) <->
+  subsumes r1 r2.
+Proof.
+  split.
+  - apply containmentImpliesSubsumption.
+  - apply subsumptionImpliesContainment.
+Qed.

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -3,8 +3,8 @@ Require Import Coq.Strings.String.
 
 (* Identifiers *)
 
-Inductive id (T : Type) : Type :=
-| makeId : string -> id T.
+Inductive id : Type -> Type :=
+| makeId : forall T, string -> id T.
 
 Inductive eid : Type := . (* Term id *)
 Inductive sid : Type := . (* Scheme id *)

--- a/main.tex
+++ b/main.tex
@@ -171,33 +171,9 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\rorder{\row_1}{\row_2}$}
-        \RightLabel{(\textsc{E-Subsumption})}
-        \UnaryInfC{$\rorder{\runion{\row_1}{\row_3}}{\runion{\row_2}{\row_3}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
           \AxiomC{}
-        \RightLabel{(\textsc{E-LeftAssociativity})}
-        \UnaryInfC{$\rorder{\runion{\parens{\runion{\row_1}{\row_2}}}{\row_3}}{\runion{\row_1}{\parens{\runion{\row_2}{\row_3}}}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-RightAssociativity})}
-        \UnaryInfC{$\rorder{\runion{\row_1}{\parens{\runion{\row_2}{\row_3}}}}{\runion{\parens{\runion{\row_1}{\row_2}}}{\row_3}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-LeftContraction})}
+        \RightLabel{(\textsc{E-Contraction})}
         \UnaryInfC{$\rorder{\runion{\row}{\row}}{\row}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{E-RightContraction})}
-        \UnaryInfC{$\rorder{\row}{\runion{\row}{\row}}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -213,15 +189,21 @@
       \end{prooftree}
 
       \begin{prooftree}
+          \AxiomC{$\rorder{\row_1}{\row_2}$}		
+        \RightLabel{(\textsc{E-Subsumption})}		
+        \UnaryInfC{$\rorder{\runion{\row_1}{\row_3}}{\runion{\row_2}{\row_3}}$}		
+      \end{prooftree}		
+
+      \begin{prooftree}
           \AxiomC{}
-        \RightLabel{(\textsc{E-LeftIdentity})}
-        \UnaryInfC{$\rorder{\runion{\rempty}{\row}}{\row}$}
+        \RightLabel{(\textsc{E-Identity})}
+        \UnaryInfC{$\rorder{\rempty}{\row}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{}
-        \RightLabel{(\textsc{E-RightIdentity})}
-        \UnaryInfC{$\rorder{\row}{\runion{\rempty}{\row}}$}
+        \RightLabel{(\textsc{E-Associativity})}
+        \UnaryInfC{$\rorder{\runion{\parens{\runion{\row_1}{\row_2}}}{\row_3}}{\runion{\row_1}{\parens{\runion{\row_2}{\row_3}}}}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
Formalize in Coq the correctness proposition for effect row subsumption:

```coq
Theorem subsumptionCorrect :
  forall r1 r2, (
    forall s1,
    rowContains r1 s1 ->
    exists s2,
    (schemeEq s1 s2 /\ rowContains r2 s2)
  ) <->
  subsumes r1 r2.
```

Let's try to prove this theorem!

Also I updated the row subsumption rules in both LaTeX and Coq:

- I removed `E-RightAssociativity` because it can be recovered from a combination of the other associativity rule and exchange.
- I removed `E-RightContraction` because `E-Weakening` already generalizes it.
- I replaced `E-LeftIdentity` and `E-RightIdentity` with a unified `E-Identity` rule.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subsumption-correctness-proposition.pdf) is a link to the PDF generated from this PR.