### PR TITLE
Prove that effect row subsumption implies containment up to effect row equivalence

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -97,6 +97,15 @@ with schemeEq : scheme -> scheme -> Prop :=
 | seRefl :
     forall s,
     schemeEq s s
+| seSymm :
+    forall s1 s2,
+    schemeEq s1 s2 ->
+    schemeEq s2 s1
+| seTrans :
+    forall s1 s2 s3,
+    schemeEq s1 s2 ->
+    schemeEq s2 s3 ->
+    schemeEq s1 s3
 (* TODO: Fill in the other rules here. *)
 
 (* Kind equivalence *)

--- a/formalization/subsumption.v
+++ b/formalization/subsumption.v
@@ -14,34 +14,119 @@ Inductive rowContains : row -> scheme -> Prop :=
     rowContains r2 s ->
     rowContains (runion r1 r2) s.
 
-Lemma containmentImpliesSubsumption :
-  forall r1 r2, (
-    forall s1,
-    rowContains r1 s1 ->
-    exists s2,
-    (schemeEq s1 s2 /\ rowContains r2 s2)
-  ) ->
-  subsumes r1 r2.
+Definition containment r1 r2 :=
+  forall s1,
+  rowContains r1 s1 ->
+  exists s2,
+  (schemeEq s1 s2 /\ rowContains r2 s2).
+
+Lemma containmentImpliesSubsumption : forall r1 r2, containment r1 r2 -> subsumes r1 r2.
 Admitted.
 
-Lemma subsumptionImpliesContainment :
-  forall r1 r2,
-  subsumes r1 r2 -> (
-    forall s1,
-    rowContains r1 s1 ->
-    exists s2,
-    (schemeEq s1 s2 /\ rowContains r2 s2)
-  ).
-Admitted.
+Lemma subsumptionImpliesContainment : forall r1 r2, subsumes r1 r2 -> containment r1 r2.
+Proof.
+  intros r1 r2 H.
+  unfold containment.
+  induction H.
+  (* rsRefl *)
+  - intros.
+    exists s1.
+    split.
+    + apply seRefl.
+    + auto.
+  (* rsTrans *)
+  - intros.
+    destruct IHsubsumes1 with (s1 := s1).
+    + auto.
+    + elim H2. intros.
+      destruct IHsubsumes2 with (s1 := x).
+      * auto.
+      * {
+        elim H5. intros.
+        exists x0.
+        split.
+        - apply seTrans with (s2 := x); auto.
+        - auto.
+      }
+  (* rsContract *)
+  - intros.
+    exists s1.
+    split.
+    + inversion H; apply seRefl.
+    + inversion H; auto.
+  (* rsWeaken *)
+  - intros.
+    exists s1.
+    split.
+    + apply seRefl.
+    + inversion H.
+      * apply rcUnionLeft.
+        apply rcSingleton.
+      * rewrite H1.
+        apply rcUnionLeft.
+        auto.
+      * rewrite H1.
+        apply rcUnionLeft.
+        auto.
+  (* rsExchange *)
+  - intros.
+    exists s1.
+    split.
+    + apply seRefl.
+    + inversion H.
+      * apply rcUnionRight.
+        auto.
+      * apply rcUnionLeft.
+        auto.
+  (* rsSub *)
+  - intros.
+    inversion H0.
+    + destruct IHsubsumes with (s1 := s1).
+      * auto.
+      * {
+        elim H5. intros.
+        exists x.
+        split.
+        - auto.
+        - apply rcUnionLeft.
+          auto.
+      }
+    + exists s1.
+      split.
+      * apply seRefl.
+      * apply rcUnionRight.
+        auto.
+  (* rsId *)
+  - intros.
+    exists s1.
+    inversion H.
+  (* rsAssoc *)
+  - intros.
+    destruct IHsubsumes with (s1 := s1).
+    + apply rcUnionLeft.
+      auto.
+    + elim H1. intros.
+      exists x.
+      split.
+      * auto.
+      * apply rcUnionRight.
+        auto.
+  (* rsSchemeEq *)
+  - intros.
+    exists s2.
+    intros.
+    inversion H0.
+    assert (schemeEq s0 s2).
+    + apply seTrans with (s2 := s1).
+      * rewrite H1.
+        apply seRefl.
+      * auto.
+    + split.
+      * auto.
+      * apply rcSingleton.
+Qed.
 
-Theorem subsumptionCorrect :
-  forall r1 r2, (
-    forall s1,
-    rowContains r1 s1 ->
-    exists s2,
-    (schemeEq s1 s2 /\ rowContains r2 s2)
-  ) <->
-  subsumes r1 r2.
+Theorem subsumptionCorrect : forall r1 r2, containment r1 r2 <-> subsumes r1 r2.
 Proof.
   split.
   - apply containmentImpliesSubsumption.


### PR DESCRIPTION
Our first formally verified result: effect row subsumption implies containment up to effect row equivalence. The proof relies only on the fact that effect row equivalence is a preorder. It doesn't even require it to be an equivalence relation. Also, the proof will not need to be changed when we add the remaining rules for effect row equivalence.

The proof uses the following definition of containment:

```coq
Definition containment r1 r2 :=
  forall s1,
  rowContains r1 s1 ->
  exists s2,
  (schemeEq s1 s2 /\ rowContains r2 s2).
```

@ewang12 experimented with an alternate definition where the existential quantifier is commuted with the `rowContains` hypothesis:

```coq
Definition containment r1 r2 :=
  forall s1,
  exists s2,
  rowContains r1 s1 ->
  (schemeEq s1 s2 /\ rowContains r2 s2).
```

This definition of `containment` leads to nicer sub-proofs in most of the cases. However, I was unable to prove the `rsSub` case using this version, and I'm not sure if it's possible: the current proof relies on the ability to choose `s2` _after_ inversion on the `rowContains` hypothesis (we use a different `s2` for each case).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subsumption-proof.pdf) is a link to the PDF generated from this PR.
