### PR TITLE
Fix some typos in the typing rules (caught by Esther)

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -307,7 +307,7 @@
             {$\tjudgment{\context}{\term_2}{\stwithx{\parens{\tarrow{\stwithx{\type_2}{\row_2}}{\stwithx{\type_3}{\row_3}}}}{\row_4}}$}
             {$\sorder{\stwithx{\type_1}{\rempty}}{\stwithx{\type_2}{\row_2}}$}}}
         \RightLabel{(\textsc{T-ApplicationByValue})}
-        \UnaryInfC{$\tjudgment{\context}{\eappbv{\term_2}{\term_1}}{\stwithx{\type_4}{\runion{\runion{\row_1}{\row_3}}{\row_4}}}$}
+        \UnaryInfC{$\tjudgment{\context}{\eappbv{\term_2}{\term_1}}{\stwithx{\type_3}{\runion{\runion{\row_1}{\row_3}}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -315,7 +315,7 @@
             {$\tjudgment{\context}{\term_2}{\stwithx{\parens{\tarrow{\stwithx{\type_2}{\row_2}}{\stwithx{\type_3}{\row_3}}}}{\row_4}}$}
             {$\sorder{\stwithx{\type_1}{\row_1}}{\stwithx{\type_2}{\row_2}}$}}}
         \RightLabel{(\textsc{T-ApplicationByName})}
-        \UnaryInfC{$\tjudgment{\context}{\eappbn{\term_2}{\term_1}}{\stwithx{\type_4}{\runion{\row_3}{\row_4}}}$}
+        \UnaryInfC{$\tjudgment{\context}{\eappbn{\term_2}{\term_1}}{\stwithx{\type_3}{\runion{\row_3}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
Fix some typos in the typing rules (caught by Esther).

@ewang12 were there any others?

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-fix-typos.pdf) is a link to the PDF generated from this PR.
