### PR TITLE
Remove axioms rRefl and rAssoc and add them back as theorems

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -40,9 +40,6 @@ with opTypeWellFormed : scheme -> schemeId -> Prop :=
 (* Effect row subsumption *)
 
 with subsumes : row -> row -> Prop :=
-| rRefl :
-    forall r,
-    subsumes r r
 | rTrans :
     forall r1 r2 r3,
     subsumes r1 r2 ->
@@ -66,10 +63,6 @@ with subsumes : row -> row -> Prop :=
 | rExchange :
     forall r1 r2,
     subsumes (runion r1 r2) (runion r2 r1)
-| rAssoc:
-    forall r1 r2 r3,
-    subsumes (runion r1 r2) r3 ->
-    subsumes r1 (runion r2 r3)
 
 (* Scheme equivalence *)
 

--- a/formalization/subsumption.v
+++ b/formalization/subsumption.v
@@ -14,6 +14,42 @@ Inductive rowContains : row -> scheme -> Prop :=
     rowContains r2 s ->
     rowContains (runion r1 r2) s.
 
+Theorem rRefl : forall r, subsumes r r.
+Proof.
+  intros.
+  induction r.
+  - apply rEmpty.
+  - apply rSingleton.
+    apply stRefl.
+  - apply rUnion.
+    + apply rWeaken.
+    + apply rTrans with (r2 := runion r2 r1).
+      * apply rWeaken.
+      * apply rExchange.
+Qed.
+
+Theorem rAssoc :
+  forall r1 r2 r3,
+  subsumes (runion (runion r1 r2) r3) (runion r1 (runion r2 r3)).
+Proof.
+  intros.
+  apply rUnion.
+  - apply rUnion.
+    + apply rWeaken.
+    + apply rTrans with (r2 := runion (runion r2 r3) r1).
+      * apply rTrans with (r2 := runion r2 r3); apply rWeaken.
+      * apply rExchange.
+  - apply rTrans with (r2 := runion (runion r2 r3) r1).
+    + apply rTrans with (r2 := runion r2 r3).
+      * {
+        apply rTrans with (r2 := runion r3 r2).
+        - apply rWeaken.
+        - apply rExchange.
+      }
+      * apply rWeaken.
+    + apply rExchange.
+Qed.
+
 Definition containment r1 r2 :=
   forall s1,
   rowContains r1 s1 ->
@@ -123,12 +159,6 @@ Proof.
   intros r1 r2 H.
   unfold containment.
   induction H.
-  (* rRefl *)
-  - intros.
-    exists s1.
-    split.
-    + apply stRefl.
-    + auto.
   (* rTrans *)
   - intros.
     destruct IHsubsumes1 with (s1 := s1).
@@ -194,17 +224,6 @@ Proof.
       * apply rcUnionRight.
         auto.
       * apply rcUnionLeft.
-        auto.
-  (* rAssoc *)
-  - intros.
-    destruct IHsubsumes with (s1 := s1).
-    + apply rcUnionLeft.
-      auto.
-    + elim H1. intros.
-      exists x.
-      split.
-      * auto.
-      * apply rcUnionRight.
         auto.
 Qed.
 

--- a/main.tex
+++ b/main.tex
@@ -335,12 +335,6 @@
       \medskip
 
       \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{R-Reflexivity})}
-        \UnaryInfC{$\rorder{\row}{\row}$}
-      \end{prooftree}
-
-      \begin{prooftree}
           \AxiomC{$\rorder{\row_1}{\row_2}$}
           \AxiomC{$\rorder{\row_2}{\row_3}$}
         \RightLabel{(\textsc{R-Transitivity})}
@@ -376,12 +370,6 @@
           \AxiomC{}
         \RightLabel{(\textsc{R-Exchange})}
         \UnaryInfC{$\rorder{\runion{\row_1}{\row_2}}{\runion{\row_2}{\row_1}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{R-Associativity})}
-        \UnaryInfC{$\rorder{\runion{\parens{\runion{\row_1}{\row_2}}}{\row_3}}{\runion{\row_1}{\parens{\runion{\row_2}{\row_3}}}}$}
       \end{prooftree}
 
       \caption{Effect row subsumption}\label{fig:preorder}


### PR DESCRIPTION
Remove axioms `rRefl` and `rAssoc` and add them back as theorems.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subsumption-metatheory.pdf) is a link to the PDF generated from this PR.
