### PR TITLE
Inline effect row subsumption into the subtyping rules

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -2,40 +2,40 @@ Require Import syntax.
 
 (* Typing rules *)
 
-Inductive hasType : context -> term -> scheme -> Prop :=
+Inductive hasType : context -> term -> type -> Prop :=
 | tVar :
-    forall c e s,
-    lookupEVar c e = Some s ->
-    hasType c e s
+    forall c e t,
+    lookupEVar c e = Some t ->
+    hasType c e t
 (* TODO: Fill in the other rules here. *)
 
 (* Kinding rules *)
 
-with hasKind : context -> scheme -> kind -> Prop :=
+with hasKind : context -> type -> kind -> Prop :=
 | kArrow :
-    forall c s1 s2 r,
-    hasKind c s1 ktype ->
-    hasKind c s2 ktype ->
-    hasKind c (srow r) krow ->
-    hasKind c (stwithx (tarrow s1 s2) r) ktype
+    forall c t1 t2 r,
+    hasKind c t1 ktype ->
+    hasKind c t2 ktype ->
+    hasKind c (trow r) krow ->
+    hasKind c (tptwithx (ptarrow t1 t2) r) ktype
 (* TODO: Fill in the other rules here. *)
 
 (* Operation type well-formedness *)
 
-with opTypeWellFormed : scheme -> schemeId -> Prop :=
+with opTypeWellFormed : type -> typeId -> Prop :=
 | wfArrow :
-    forall s1 s2 a r,
-    opTypeWellFormed s2 a ->
-    opTypeWellFormed (stwithx (tarrow s1 s2) r) a
+    forall t1 t2 a r,
+    opTypeWellFormed t2 a ->
+    opTypeWellFormed (tptwithx (ptarrow t1 t2) r) a
 | wfForAll :
-    forall s k r a1 a2,
-    opTypeWellFormed s a2 ->
+    forall t k r a1 a2,
+    opTypeWellFormed t a2 ->
     eqId a1 a2 = false ->
-    opTypeWellFormed (stwithx (tforall a1 k s) r) a2
+    opTypeWellFormed (tptwithx (ptforall a1 k t) r) a2
 | wfTWithEff :
     forall a r t,
-    subsumes (rsingleton (svar a)) r ->
-    opTypeWellFormed (stwithx t r) a
+    subsumes (rsingleton (tvar a)) r ->
+    opTypeWellFormed (tptwithx t r) a
 
 (* Effect row subsumption *)
 
@@ -49,9 +49,9 @@ with subsumes : row -> row -> Prop :=
     forall r1,
     subsumes rempty r1
 | rSingleton :
-    forall s1 s2,
-    subtype s1 s2 ->
-    subsumes (rsingleton s1) (rsingleton s2)
+    forall t1 t2,
+    subtype t1 t2 ->
+    subsumes (rsingleton t1) (rsingleton t2)
 | rUnion :
     forall r1 r2 r3,
     subsumes r1 r3 ->
@@ -66,31 +66,31 @@ with subsumes : row -> row -> Prop :=
 
 (* Subtyping *)
 
-with subtype : scheme -> scheme -> Prop :=
+with subtype : type -> type -> Prop :=
 | stRefl :
-    forall s,
-    subtype s s
+    forall t,
+    subtype t t
 | stTrans :
-    forall s1 s2 s3,
-    subtype s1 s2 ->
-    subtype s2 s3 ->
-    subtype s1 s3
+    forall t1 t2 t3,
+    subtype t1 t2 ->
+    subtype t2 t3 ->
+    subtype t1 t3
 | stArrow :
-    forall s1 s2 s3 s4 r1 r2,
-    subtype s3 s1 ->
-    subtype s2 s4 ->
+    forall t1 t2 t3 t4 r1 r2,
+    subtype t3 t1 ->
+    subtype t2 t4 ->
     subsumes r1 r2 ->
-    subtype (stwithx (tarrow s1 s2) r1) (stwithx (tarrow s3 s4) r2)
+    subtype (tptwithx (ptarrow t1 t2) r1) (tptwithx (ptarrow t3 t4) r2)
 | stForAll :
-    forall s1 s2 r1 r2 a k,
-    subtype s1 s2 ->
+    forall t1 t2 r1 r2 a k,
+    subtype t1 t2 ->
     subsumes r1 r2 ->
-    subtype (stwithx (tforall a k s1) r1) (stwithx (tforall a k s2) r2)
-| stSchemeAbs :
-    forall s1 s2 a k,
-    subtype s1 s2 ->
-    subtype (sabs a k s1) (sabs a k s2)
-| stSchemeApp :
-    forall s1 s2 s3,
-    subtype s1 s2 ->
-    subtype (sapp s1 s3) (sapp s2 s3).
+    subtype (tptwithx (ptforall a k t1) r1) (tptwithx (ptforall a k t2) r2)
+| stTypeAbs :
+    forall t1 t2 a k,
+    subtype t1 t2 ->
+    subtype (tabs a k t1) (tabs a k t2)
+| stTypeApp :
+    forall t1 t2 t3,
+    subtype t1 t2 ->
+    subtype (tapp t1 t3) (tapp t2 t3).

--- a/formalization/subsumption.v
+++ b/formalization/subsumption.v
@@ -37,24 +37,24 @@ Proof.
     + apply rExchange.
 Qed.
 
-Inductive rowContains : row -> scheme -> Prop :=
+Inductive rowContains : row -> type -> Prop :=
 | rcSingleton :
-    forall s,
-    rowContains (rsingleton s) s
+    forall t,
+    rowContains (rsingleton t) t
 | rcUnionLeft :
-    forall r1 r2 s,
-    rowContains r1 s ->
-    rowContains (runion r1 r2) s
+    forall r1 r2 t,
+    rowContains r1 t ->
+    rowContains (runion r1 r2) t
 | rcUnionRight :
-    forall r1 r2 s,
-    rowContains r2 s ->
-    rowContains (runion r1 r2) s.
+    forall r1 r2 t,
+    rowContains r2 t ->
+    rowContains (runion r1 r2) t.
 
 Definition containment r1 r2 :=
-  forall s1,
-  rowContains r1 s1 ->
-  exists s2,
-  (subtype s1 s2 /\ rowContains r2 s2).
+  forall t1,
+  rowContains r1 t1 ->
+  exists t2,
+  (subtype t1 t2 /\ rowContains r2 t2).
 
 Lemma subsumptionImpliesContainment :
   forall r1 r2,
@@ -66,29 +66,29 @@ Proof.
   induction H.
   (* rTrans *)
   - intros.
-    destruct IHsubsumes1 with (s1 := s1).
+    destruct IHsubsumes1 with (t1 := t1).
     + auto.
     + elim H2. intros.
-      destruct IHsubsumes2 with (s1 := x).
+      destruct IHsubsumes2 with (t1 := x).
       * auto.
       * {
         elim H5. intros.
         exists x0.
         split.
-        - apply stTrans with (s2 := x); auto.
+        - apply stTrans with (t2 := x); auto.
         - auto.
       }
   (* rEmpty *)
   - intros.
-    exists s1.
+    exists t1.
     inversion H.
   (* rSingleton *)
   - intros.
-    exists s2.
+    exists t2.
     intros.
     inversion H0.
-    assert (subtype s0 s2).
-    + apply stTrans with (s2 := s1).
+    assert (subtype t0 t2).
+    + apply stTrans with (t2 := t1).
       * rewrite H1.
         apply stRefl.
       * auto.
@@ -98,17 +98,17 @@ Proof.
   (* rUnion *)
   - intros.
     inversion H1.
-    + destruct IHsubsumes1 with (s1 := s1).
+    + destruct IHsubsumes1 with (t1 := t1).
       * auto.
       * exists x.
         auto.
-    + destruct IHsubsumes2 with (s1 := s1).
+    + destruct IHsubsumes2 with (t1 := t1).
       * auto.
       * exists x.
         auto.
   (* rWeaken *)
   - intros.
-    exists s1.
+    exists t1.
     split.
     + apply stRefl.
     + inversion H.
@@ -122,7 +122,7 @@ Proof.
         auto.
   (* rExchange *)
   - intros.
-    exists s1.
+    exists t1.
     split.
     + apply stRefl.
     + inversion H.
@@ -145,30 +145,30 @@ Proof.
   (* rsingleton *)
   - induction r2.
     (* rempty *)
-    + set (H1 := H s).
-      set (H2 := H1 (rcSingleton s)).
+    + set (H1 := H t).
+      set (H2 := H1 (rcSingleton t)).
       elim H2. intros.
       elim H0. intros.
       inversion H4.
     (* rsingleton *)
-    + set (H1 := H s).
-      set (H2 := H1 (rcSingleton s)).
+    + set (H1 := H t).
+      set (H2 := H1 (rcSingleton t)).
       elim H2. intros.
       elim H0. intros.
       inversion H4.
       apply rSingleton. auto.
     (* runion *)
-    + set (H1 := H s).
-      set (H2 := H1 (rcSingleton s)).
+    + set (H1 := H t).
+      set (H2 := H1 (rcSingleton t)).
       elim H2. intros.
       elim H0. intros.
       inversion H4.
       * {
         assert (
-          forall s1 : scheme,
-          rowContains (rsingleton s) s1 ->
-          exists s2 : scheme,
-          subtype s1 s2 /\ rowContains r2_1 s2
+          forall t1 : type,
+          rowContains (rsingleton t) t1 ->
+          exists t2 : type,
+          subtype t1 t2 /\ rowContains r2_1 t2
         ).
         - intros.
           exists x.
@@ -181,10 +181,10 @@ Proof.
       }
       * {
         assert (
-          forall s1 : scheme,
-          rowContains (rsingleton s) s1 ->
-          exists s2 : scheme,
-          subtype s1 s2 /\ rowContains r2_2 s2
+          forall t1 : type,
+          rowContains (rsingleton t) t1 ->
+          exists t2 : type,
+          subtype t1 t2 /\ rowContains r2_2 t2
         ).
         - intros.
           exists x.
@@ -199,27 +199,27 @@ Proof.
       }
   (* runion *)
   - assert (
-      forall s1 : scheme,
-      rowContains r1_1 s1 ->
-      exists s2 : scheme,
-      subtype s1 s2 /\ rowContains r2 s2
+      forall t1 : type,
+      rowContains r1_1 t1 ->
+      exists t2 : type,
+      subtype t1 t2 /\ rowContains r2 t2
     ).
     + intros.
-      set (H1 := H s1).
-      assert (rowContains (runion r1_1 r1_2) s1).
+      set (H1 := H t1).
+      assert (rowContains (runion r1_1 r1_2) t1).
       * apply rcUnionLeft. auto.
       * set (H3 := H1 H2).
         auto.
     + assert (
-        forall s1 : scheme,
-        rowContains r1_2 s1 ->
-        exists s2 : scheme,
-        subtype s1 s2 /\ rowContains r2 s2
+        forall t1 : type,
+        rowContains r1_2 t1 ->
+        exists t2 : type,
+        subtype t1 t2 /\ rowContains r2 t2
       ).
       * {
         intros.
-        set (H2 := H s1).
-        assert (rowContains (runion r1_1 r1_2) s1).
+        set (H2 := H t1).
+        assert (rowContains (runion r1_1 r1_2) t1).
         - apply rcUnionRight. auto.
         - set (H4 := H2 H3).
           auto.

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -6,43 +6,43 @@ Inductive id : Type -> Type :=
 | makeId : forall T, string -> id T.
 
 Inductive eid : Type := . (* Term id *)
-Inductive sid : Type := . (* Scheme id *)
+Inductive tid : Type := . (* Type id *)
 
 Definition termId := id eid.
-Definition schemeId := id sid.
+Definition typeId := id tid.
 
 (* Terms *)
 
 Inductive term : Type :=
 | evar : termId -> term
-| eabs : termId -> scheme -> term -> term
+| eabs : termId -> type -> term -> term
 | eappbv : term -> term -> term
 | eappbn : term -> term -> term
-| esabs : schemeId -> kind -> term -> term
-| esapp : term -> scheme -> term
-| eeffect : schemeId -> kind -> term -> term
-| eprovide : scheme -> termId -> term -> term -> term
-
-(* Schemes *)
-
-with scheme : Type :=
-| stwithx : type -> row -> scheme
-| srow : row -> scheme
-| svar : schemeId -> scheme
-| sabs : schemeId -> kind -> scheme -> scheme
-| sapp : scheme -> scheme -> scheme
+| etabs : typeId -> kind -> term -> term
+| etapp : term -> type -> term
+| eeffect : typeId -> kind -> term -> term
+| eprovide : type -> termId -> term -> term -> term
 
 (* Types *)
 
 with type : Type :=
-| tarrow : scheme -> scheme -> type
-| tforall : schemeId -> kind -> scheme -> type
+| tptwithx : properType -> row -> type
+| trow : row -> type
+| tvar : typeId -> type
+| tabs : typeId -> kind -> type -> type
+| tapp : type -> type -> type
+
+(* Proper types *)
+
+with properType : Type :=
+| ptarrow : type -> type -> properType
+| ptforall : typeId -> kind -> type -> properType
 
 (* Effect rows *)
 
 with row : Type :=
 | rempty : row
-| rsingleton : scheme -> row
+| rsingleton : type -> row
 | runion : row -> row -> row
 
 (* Kinds *)
@@ -50,21 +50,21 @@ with row : Type :=
 with kind : Type :=
 | ktype : kind
 | krow : kind
-| keffect : schemeId -> termId -> scheme -> kind
-| karrow : schemeId -> kind -> kind -> kind.
+| keffect : typeId -> termId -> type -> kind
+| karrow : typeId -> kind -> kind -> kind.
 
 (* Type contexts *)
 
 Inductive context : Type :=
 | cempty : context
-| ceextend : context -> termId -> scheme -> context
-| csextend : context -> schemeId -> kind -> context.
+| ceextend : context -> termId -> type -> context
+| csextend : context -> typeId -> kind -> context.
 
 (* Notation "'@'" := makeId (at level 10). *)
-Notation "t1 '→' t2" := (tarrow t1 t2) (at level 38).
+Notation "t1 '→' t2" := (ptarrow t1 t2) (at level 38).
 Notation "'λ' i '∈' t '⇒' e" := (eabs i t e) (at level 39).
 Notation "'Ø'" := cempty.
-Notation "c ',e' i '∈' s" := (ceextend c i s) (at level 39).
+Notation "c ',e' i '∈' t" := (ceextend c i t) (at level 39).
 Notation "c ',s' i '∈' k" := (csextend c i k) (at level 39).
 
 Definition eqId {X : Set} (i1 : id X) (i2 : id X) : bool :=
@@ -78,22 +78,22 @@ Fixpoint lookupEVar (c1 : context) e :=
   match e with
   | evar i1 => match c1 with
                | cempty => None
-               | ceextend c2 i2 s => if eqId i1 i2
-                                     then Some s
+               | ceextend c2 i2 t => if eqId i1 i2
+                                     then Some t
                                      else lookupEVar c2 e
                | csextend c2 i2 k => lookupEVar c2 e
                end
   | _ => None
   end.
 
-Fixpoint lookupSVar (c1 : context) e :=
+Fixpoint lookupTVar (c1 : context) e :=
   match e with
-  | svar i1 => match c1 with
+  | tvar i1 => match c1 with
                | cempty => None
-               | ceextend c2 i2 s => lookupSVar c2 e
+               | ceextend c2 i2 t => lookupTVar c2 e
                | csextend c2 i2 k => if eqId i1 i2
                                      then Some k
-                                     else lookupSVar c2 e
+                                     else lookupTVar c2 e
                end
   | _ => None
   end.

--- a/main.tex
+++ b/main.tex
@@ -84,8 +84,7 @@
 % Judgements
 \newcommand\tjudgment[3]{#1 \vdash \anno{#2}{#3}} % chktex 1
 \newcommand\opwellformed[2]{#1 \; \triangleright \; #2} % chktex 1
-\newcommand\rorder[2]{#1 \; \sqsubseteq \; #2} % chktex 1
-\newcommand\sorder[2]{#1 \; \sqsubseteq \; #2} % chktex 1
+\newcommand\subtype[2]{#1 \; \sqsubseteq \; #2} % chktex 1
 
 %%%%%%%%%%%%%%%%%%%%%
 % The specification %
@@ -172,7 +171,7 @@
       \begin{prooftree}
           \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\stwithx{\type_1}{\row_1}}$}
             {$\tjudgment{\context}{\term_2}{\stwithx{\parens{\tarrow{\stwithx{\type_2}{\row_2}}{\stwithx{\type_3}{\row_3}}}}{\row_4}}$}
-            {$\sorder{\stwithx{\type_1}{\rempty}}{\stwithx{\type_2}{\row_2}}$}}}
+            {$\subtype{\stwithx{\type_1}{\rempty}}{\stwithx{\type_2}{\row_2}}$}}}
         \RightLabel{(\textsc{T-ApplicationByValue})}
         \UnaryInfC{$\tjudgment{\context}{\eappbv{\term_2}{\term_1}}{\stwithx{\type_3}{\runion{\runion{\row_1}{\row_3}}{\row_4}}}$}
       \end{prooftree}
@@ -180,7 +179,7 @@
       \begin{prooftree}
           \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\stwithx{\type_1}{\row_1}}$}
             {$\tjudgment{\context}{\term_2}{\stwithx{\parens{\tarrow{\stwithx{\type_2}{\row_2}}{\stwithx{\type_3}{\row_3}}}}{\row_4}}$}
-            {$\sorder{\stwithx{\type_1}{\row_1}}{\stwithx{\type_2}{\row_2}}$}}}
+            {$\subtype{\stwithx{\type_1}{\row_1}}{\stwithx{\type_2}{\row_2}}$}}}
         \RightLabel{(\textsc{T-ApplicationByName})}
         \UnaryInfC{$\tjudgment{\context}{\eappbn{\term_2}{\term_1}}{\stwithx{\type_3}{\runion{\row_3}{\row_4}}}$}
       \end{prooftree}
@@ -214,14 +213,14 @@
           \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\scheme_1}$}
             {$\tjudgment{\context}{\term_2}{\stwithx{\type}{\row}}$}
             {$\tjudgment{\context}{\scheme_2}{\keffect{\svar}{\evar}{\scheme_3}}$}
-            {$\sorder{\scheme_1}{\sub{\scheme_3}{\svar}{\keffect{\svar}{\evar}{\scheme_3}}}$}}}
+            {$\subtype{\scheme_1}{\sub{\scheme_3}{\svar}{\keffect{\svar}{\evar}{\scheme_3}}}$}}}
         \RightLabel{(\textsc{T-Provide})}
         \UnaryInfC{$\tjudgment{\context}{\parens{\eprovide{\scheme_2}{\evar}{\term_1}{\term_2}}}{\stwithx{\type}\rdiff{\row}{\rsingleton{\scheme_2}}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\context}{\term}{\scheme_1}$}
-          \AxiomC{$\sorder{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
         \RightLabel{(\textsc{T-Subsumption})}
         \BinaryInfC{$\tjudgment{\context}{\term}{\scheme_2}$}
       \end{prooftree}
@@ -317,7 +316,7 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\rorder{\rsingleton{\svar}}{\row}$}
+          \AxiomC{$\subtype{\rsingleton{\svar}}{\row}$}
         \RightLabel{(\textsc{WF-TypeWithEffects})}
         \UnaryInfC{$\opwellformed{\stwithx{\type}{\row}}{\svar}$}
       \end{prooftree}
@@ -329,57 +328,7 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\rorder{\row}{\row}$}
-      \end{center}
-
-      \medskip
-
-      \begin{prooftree}
-          \AxiomC{$\rorder{\row_1}{\row_2}$}
-          \AxiomC{$\rorder{\row_2}{\row_3}$}
-        \RightLabel{(\textsc{R-Transitivity})}
-        \BinaryInfC{$\rorder{\row_1}{\row_3}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{R-Empty})}
-        \UnaryInfC{$\rorder{\rempty}{\row}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\sorder{\scheme_1}{\scheme_2}$}
-        \RightLabel{(\textsc{R-Singleton})}
-        \UnaryInfC{$\rorder{\rsingleton{\scheme_1}}{\rsingleton{\scheme_2}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\rorder{\row_1}{\row_3}$}
-          \AxiomC{$\rorder{\row_2}{\row_3}$}
-        \RightLabel{(\textsc{R-Union})}
-        \BinaryInfC{$\rorder{\runion{\row_1}{\row_2}}{\row_3}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{R-Weakening})}
-        \UnaryInfC{$\rorder{\row_1}{\runion{\row_1}{\row_2}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{}
-        \RightLabel{(\textsc{R-Exchange})}
-        \UnaryInfC{$\rorder{\runion{\row_1}{\row_2}}{\runion{\row_2}{\row_1}}$}
-      \end{prooftree}
-
-      \caption{Effect row subsumption}\label{fig:preorder}
-    \end{mdframed}
-  \end{figure}
-
-  \begin{figure}
-    \begin{mdframed}[backgroundcolor=none]
-      \begin{center}
-        \framebox{$\sorder{\scheme}{\scheme}$}
+        \framebox{$\subtype{\scheme}{\scheme}$}
       \end{center}
 
       \medskip
@@ -387,41 +336,72 @@
       \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{ST-Reflexivity})}
-        \UnaryInfC{$\sorder{\scheme}{\scheme}$}
+        \UnaryInfC{$\subtype{\scheme}{\scheme}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\sorder{\scheme_1}{\scheme_2}$}
-          \AxiomC{$\sorder{\scheme_2}{\scheme_3}$}
+          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\subtype{\scheme_2}{\scheme_3}$}
         \RightLabel{(\textsc{ST-Transitivity})}
-        \BinaryInfC{$\sorder{\scheme_1}{\scheme_3}$}
+        \BinaryInfC{$\subtype{\scheme_1}{\scheme_3}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\sorder{\scheme_3}{\scheme_1}$}
-          \AxiomC{$\sorder{\scheme_2}{\scheme_4}$}
-          \AxiomC{$\sorder{\row_1}{\row_2}$}
+          \AxiomC{$\subtype{\scheme_3}{\scheme_1}$}
+          \AxiomC{$\subtype{\scheme_2}{\scheme_4}$}
+          \AxiomC{$\subtype{\row_1}{\row_2}$}
         \RightLabel{(\textsc{ST-Arrow})}
-        \TrinaryInfC{$\sorder{\stwithx{\parens{\tarrow{\scheme_1}{\scheme_2}}}{\row_1}}{\stwithx{\parens{\tarrow{\scheme_3}{\scheme_4}}}{\row_2}}$}
+        \TrinaryInfC{$\subtype{\stwithx{\parens{\tarrow{\scheme_1}{\scheme_2}}}{\row_1}}{\stwithx{\parens{\tarrow{\scheme_3}{\scheme_4}}}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\sorder{\scheme_1}{\scheme_2}$}
-          \AxiomC{$\sorder{\row_1}{\row_2}$}
+          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\subtype{\row_1}{\row_2}$}
         \RightLabel{(\textsc{ST-ForAll})}
-        \BinaryInfC{$\sorder{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme_1}}}{\row_1}}{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme_2}}}{\row_2}}$}
+        \BinaryInfC{$\subtype{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme_1}}}{\row_1}}{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme_2}}}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\sorder{\scheme_1}{\scheme_2}$}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Empty})}
+        \UnaryInfC{$\subtype{\rempty}{\row}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
+        \RightLabel{(\textsc{ST-Singleton})}
+        \UnaryInfC{$\subtype{\rsingleton{\scheme_1}}{\rsingleton{\scheme_2}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{$\subtype{\row_1}{\row_3}$}
+          \AxiomC{$\subtype{\row_2}{\row_3}$}
+        \RightLabel{(\textsc{ST-Union})}
+        \BinaryInfC{$\subtype{\runion{\row_1}{\row_2}}{\row_3}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Weakening})}
+        \UnaryInfC{$\subtype{\row_1}{\runion{\row_1}{\row_2}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Exchange})}
+        \UnaryInfC{$\subtype{\runion{\row_1}{\row_2}}{\runion{\row_2}{\row_1}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
         \RightLabel{(\textsc{ST-SchemeAbstraction})}
-        \UnaryInfC{$\sorder{\sabs{\anno{\svar}{\kind}}{\scheme_1}}{\sabs{\anno{\svar}{\kind}}{\scheme_2}}$}
+        \UnaryInfC{$\subtype{\sabs{\anno{\svar}{\kind}}{\scheme_1}}{\sabs{\anno{\svar}{\kind}}{\scheme_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\sorder{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
         \RightLabel{(\textsc{ST-SchemeApplication})}
-        \UnaryInfC{$\sorder{\sapp{\scheme_1}{\scheme_3}}{\sapp{\scheme_2}{\scheme_3}}$}
+        \UnaryInfC{$\subtype{\sapp{\scheme_1}{\scheme_3}}{\sapp{\scheme_2}{\scheme_3}}$}
       \end{prooftree}
 
       \caption{Subtyping}\label{fig:subtyping}

--- a/main.tex
+++ b/main.tex
@@ -44,22 +44,22 @@
 \newcommand\eabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
 \newcommand\eappbv[2]{#1 \left\llbracket #2 \right\rrbracket_{\textsc{V}}} % chktex 1
 \newcommand\eappbn[2]{#1 \left\llbracket #2 \right\rrbracket_{\textsc{N}}} % chktex 1
-\newcommand\esabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
-\newcommand\esapp[2]{#1 \; #2}
+\newcommand\etabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
+\newcommand\etapp[2]{#1 \; #2}
 \newcommand\eeffect[3]{\textbf{effect} \; \anno{#1}{#2} \; \textbf{in} \; #3}
 \newcommand\eprovide[4]{\textbf{provide} \; #1 \; \textbf{with} \; #2 = #3 \; \textbf{in} \; #4}
 
-% Schemes
-\newcommand\scheme{\sigma}
-\newcommand\stwithx[2]{#1 \; ! \; #2} % chktex 26
-\newcommand\svar{\alpha}
-\newcommand\sabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
-\newcommand\sapp[2]{#1 \; #2} % chktex 1 chktex 26
-
 % Types
-\newcommand\type{\tau}
-\newcommand\tarrow[2]{#1 \rightarrow #2} % chktex 1
-\newcommand\tforall[2]{\forall #1 \; . \; #2} % chktex 1 chktex 26
+\newcommand\type{\sigma}
+\newcommand\tptwithx[2]{#1 \; ! \; #2} % chktex 26
+\newcommand\tvar{\alpha}
+\newcommand\tabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
+\newcommand\tapp[2]{#1 \; #2} % chktex 1 chktex 26
+
+% Proper types
+\newcommand\properType{\tau}
+\newcommand\ptarrow[2]{#1 \rightarrow #2} % chktex 1
+\newcommand\ptforall[2]{\forall #1 \; . \; #2} % chktex 1 chktex 26
 
 % Effect rows
 \newcommand\row{\varepsilon}
@@ -105,40 +105,40 @@
         \begin{tabular}{l l l}
           $\term \Coloneqq $ & & terms: \\
           & $\evar$ & variable \\
-          & $\eabs{\anno{\evar}{\scheme}}{\term}$ & abstraction \\
+          & $\eabs{\anno{\evar}{\type}}{\term}$ & abstraction \\
           & $\eappbv{\term}{\term}$ & application by value \\
           & $\eappbn{\term}{\term}$ & application by name \\
-          & $\esabs{\anno{\svar}{\kind}}{\term}$ & scheme abstraction \\
-          & $\esapp{\term}{\scheme}$ & scheme application \\
-          & $\eeffect{\svar}{\kind}{\term}$ & effect declaration \\
-          & $\eprovide{\scheme}{\evar}{\term}{\term}$ & effect definition \\
-          \\
-          $\scheme \Coloneqq$ & & schemes: \\
-          & $\stwithx{\type}{\row}$ & type with effects \\
-          & $\row$ & effect row \\
-          & $\svar$ & scheme variable \\
-          & $\sabs{\anno{\svar}{\kind}}{\scheme}$ & operator abstraction \\
-          & $\sapp{\scheme}{\scheme}$ & operator application \\
+          & $\etabs{\anno{\tvar}{\kind}}{\term}$ & type abstraction \\
+          & $\etapp{\term}{\type}$ & type application \\
+          & $\eeffect{\tvar}{\kind}{\term}$ & effect declaration \\
+          & $\eprovide{\type}{\evar}{\term}{\term}$ & effect definition \\
           \\
           $\type \Coloneqq$ & & types: \\
-          & $\tarrow{\scheme}{\scheme}$ & arrow type \\
-          & $\tforall{\anno{\svar}{\kind}}{\scheme}$ & quantified type \\
+          & $\tptwithx{\properType}{\row}$ & proper type with effects \\
+          & $\row$ & effect row \\
+          & $\tvar$ & type variable \\
+          & $\tabs{\anno{\tvar}{\kind}}{\type}$ & operator abstraction \\
+          & $\tapp{\type}{\type}$ & operator application \\
+          \\
+          $\properType \Coloneqq$ & & proper types: \\
+          & $\ptarrow{\type}{\type}$ & arrow type \\
+          & $\ptforall{\anno{\tvar}{\kind}}{\type}$ & quantified type \\
           \\
           $\row \Coloneqq$ & & effect rows: \\
           & $\rempty$ & empty effect row \\
-          & $\rsingleton{\scheme}$ & singleton effect row \\
+          & $\rsingleton{\type}$ & singleton effect row \\
           & $\runion{\row}{\row}$ & effect row union \\
           \\
           $\kind \Coloneqq $ & & kinds: \\
-          & $\ktype$ & kind of proper types \\
+          & $\ktype$ & kind of proper types with effects \\
           & $\krow$ & kind of effect rows \\
-          & $\keffect{\svar}{\evar}{\scheme}$ & kind of effects \\
-          & $\karrow{\anno{\svar}{\kind}}{\kind}$ & kind of operators \\
+          & $\keffect{\tvar}{\evar}{\type}$ & kind of effects \\
+          & $\karrow{\anno{\tvar}{\kind}}{\kind}$ & kind of operators \\
           \\
           $\context \Coloneqq$ & & contexts: \\
           & $\cempty$ & empty context \\
-          & $\ceextend{\context}{\anno{\evar}{\scheme}}$ & term variable binding \\
-          & $\csextend{\context}{\anno{\svar}{\kind}}$ & scheme variable binding \\
+          & $\ceextend{\context}{\anno{\evar}{\type}}$ & term variable binding \\
+          & $\csextend{\context}{\anno{\tvar}{\kind}}$ & type variable binding \\
         \end{tabular}
       \end{center}
 
@@ -149,80 +149,80 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\tjudgment{\context}{\term}{\scheme}$}
+        \framebox{$\tjudgment{\context}{\term}{\type}$}
       \end{center}
 
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\anno{\evar}{\scheme} \in \context$}
+          \AxiomC{$\anno{\evar}{\type} \in \context$}
         \RightLabel{(\textsc{T-Variable})}
-        \UnaryInfC{$\tjudgment{\context}{\evar}{\scheme}$}
+        \UnaryInfC{$\tjudgment{\context}{\evar}{\type}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\ceextend{\context}{\anno{\evar}{\scheme_1}}}{\term}{\scheme_2}$}
-          \AxiomC{$\tjudgment{\context}{\scheme_1}{\ktype}$}
+          \AxiomC{$\tjudgment{\ceextend{\context}{\anno{\evar}{\type_1}}}{\term}{\type_2}$}
+          \AxiomC{$\tjudgment{\context}{\type_1}{\ktype}$}
           \AxiomC{$\evar \notin \dom{\context}$}
         \RightLabel{(\textsc{T-Abstraction})}
-        \TrinaryInfC{$\tjudgment{\context}{\parens{\eabs{\anno{\evar}{\scheme_1}}{\term}}}{\tarrow{\scheme_1}{\scheme_2}}$}
+        \TrinaryInfC{$\tjudgment{\context}{\parens{\eabs{\anno{\evar}{\type_1}}{\term}}}{\ptarrow{\type_1}{\type_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\stwithx{\type_1}{\row_1}}$}
-            {$\tjudgment{\context}{\term_2}{\stwithx{\parens{\tarrow{\stwithx{\type_2}{\row_2}}{\stwithx{\type_3}{\row_3}}}}{\row_4}}$}
-            {$\subtype{\stwithx{\type_1}{\rempty}}{\stwithx{\type_2}{\row_2}}$}}}
+          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\tptwithx{\properType_1}{\row_1}}$}
+            {$\tjudgment{\context}{\term_2}{\tptwithx{\parens{\ptarrow{\tptwithx{\properType_2}{\row_2}}{\tptwithx{\properType_3}{\row_3}}}}{\row_4}}$}
+            {$\subtype{\tptwithx{\properType_1}{\rempty}}{\tptwithx{\properType_2}{\row_2}}$}}}
         \RightLabel{(\textsc{T-ApplicationByValue})}
-        \UnaryInfC{$\tjudgment{\context}{\eappbv{\term_2}{\term_1}}{\stwithx{\type_3}{\runion{\runion{\row_1}{\row_3}}{\row_4}}}$}
+        \UnaryInfC{$\tjudgment{\context}{\eappbv{\term_2}{\term_1}}{\tptwithx{\properType_3}{\runion{\runion{\row_1}{\row_3}}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\stwithx{\type_1}{\row_1}}$}
-            {$\tjudgment{\context}{\term_2}{\stwithx{\parens{\tarrow{\stwithx{\type_2}{\row_2}}{\stwithx{\type_3}{\row_3}}}}{\row_4}}$}
-            {$\subtype{\stwithx{\type_1}{\row_1}}{\stwithx{\type_2}{\row_2}}$}}}
+          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\tptwithx{\properType_1}{\row_1}}$}
+            {$\tjudgment{\context}{\term_2}{\tptwithx{\parens{\ptarrow{\tptwithx{\properType_2}{\row_2}}{\tptwithx{\properType_3}{\row_3}}}}{\row_4}}$}
+            {$\subtype{\tptwithx{\properType_1}{\row_1}}{\tptwithx{\properType_2}{\row_2}}$}}}
         \RightLabel{(\textsc{T-ApplicationByName})}
-        \UnaryInfC{$\tjudgment{\context}{\eappbn{\term_2}{\term_1}}{\stwithx{\type_3}{\runion{\row_3}{\row_4}}}$}
+        \UnaryInfC{$\tjudgment{\context}{\eappbn{\term_2}{\term_1}}{\tptwithx{\properType_3}{\runion{\row_3}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\csextend{\context}{\anno{\svar}{\kind}}}{\term}{\scheme}$}
-          \AxiomC{$\svar \notin \dom{\context}$}
-        \RightLabel{(\textsc{T-SchemeAbstraction})}
-        \BinaryInfC{$\tjudgment{\context}{\parens{\esabs{\anno{\svar}{\kind}}{\term}}}{\tforall{\anno{\svar}{\kind}}{\scheme}}$}
+          \AxiomC{$\tjudgment{\csextend{\context}{\anno{\tvar}{\kind}}}{\term}{\type}$}
+          \AxiomC{$\tvar \notin \dom{\context}$}
+        \RightLabel{(\textsc{T-TypeAbstraction})}
+        \BinaryInfC{$\tjudgment{\context}{\parens{\etabs{\anno{\tvar}{\kind}}{\term}}}{\ptforall{\anno{\tvar}{\kind}}{\type}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\context}{\term}{\tforall{\anno{\svar}{\kind}}{\scheme_1}}$}
-          \AxiomC{$\tjudgment{\context}{\scheme_2}{\kind}$}
-        \RightLabel{(\textsc{T-SchemeApplication})}
-        \BinaryInfC{$\tjudgment{\context}{\esapp{\term}{\scheme_2}}{\sub{\scheme_1}{\svar}{\scheme_2}}$}
+          \AxiomC{$\tjudgment{\context}{\term}{\ptforall{\anno{\tvar}{\kind}}{\type_1}}$}
+          \AxiomC{$\tjudgment{\context}{\type_2}{\kind}$}
+        \RightLabel{(\textsc{T-TypeApplication})}
+        \BinaryInfC{$\tjudgment{\context}{\etapp{\term}{\type_2}}{\sub{\type_1}{\tvar}{\type_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\opwellformed{\scheme_1}{\svar_3}$}
-            {$\tjudgment{\csextend{\csextend{\context}{\lstof{\anno{\svar_2^i}{\kind^i}}}}{\anno{\svar_3}{\keffect{\svar_3}{\evar}{\scheme_1}}}}{\scheme_1}{\ktype}$}
-            {$\svar_1 \notin \scheme_2$}
-            {$\svar_1 \notin \dom{\context}$}
+          \AxiomC{\Shortstack[c]{{$\opwellformed{\type_1}{\tvar_3}$}
+            {$\tjudgment{\csextend{\csextend{\context}{\lstof{\anno{\tvar_2^i}{\kind^i}}}}{\anno{\tvar_3}{\keffect{\tvar_3}{\evar}{\type_1}}}}{\type_1}{\ktype}$}
+            {$\tvar_1 \notin \type_2$}
+            {$\tvar_1 \notin \dom{\context}$}
             {$\evar \notin \dom{\context}$}
-            {$\tjudgment{\ceextend{\csextend{\context}{\anno{\svar_1}{\karrow{\lstof{\anno{\svar_2^i}{\kind^i}}}{\keffect{\svar_3}{\evar}{\scheme_1}}}}}{\anno{\evar}{\scheme_1}}}{\term}{\scheme_2}$}}}
+            {$\tjudgment{\ceextend{\csextend{\context}{\anno{\tvar_1}{\karrow{\lstof{\anno{\tvar_2^i}{\kind^i}}}{\keffect{\tvar_3}{\evar}{\type_1}}}}}{\anno{\evar}{\type_1}}}{\term}{\type_2}$}}}
         \RightLabel{(\textsc{T-Effect})}
-        \UnaryInfC{$\tjudgment{\context}{\parens{\eeffect{\svar_1}{\karrow{\lstof{\anno{\svar_2^i}{\kind^i}}}{\keffect{\svar_3}{\evar}{\scheme_1}}}{\term}}}{\scheme_2}$}
+        \UnaryInfC{$\tjudgment{\context}{\parens{\eeffect{\tvar_1}{\karrow{\lstof{\anno{\tvar_2^i}{\kind^i}}}{\keffect{\tvar_3}{\evar}{\type_1}}}{\term}}}{\type_2}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\scheme_1}$}
-            {$\tjudgment{\context}{\term_2}{\stwithx{\type}{\row}}$}
-            {$\tjudgment{\context}{\scheme_2}{\keffect{\svar}{\evar}{\scheme_3}}$}
-            {$\subtype{\scheme_1}{\sub{\scheme_3}{\svar}{\keffect{\svar}{\evar}{\scheme_3}}}$}}}
+          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\type_1}$}
+            {$\tjudgment{\context}{\term_2}{\tptwithx{\properType}{\row}}$}
+            {$\tjudgment{\context}{\type_2}{\keffect{\tvar}{\evar}{\type_3}}$}
+            {$\subtype{\type_1}{\sub{\type_3}{\tvar}{\keffect{\tvar}{\evar}{\type_3}}}$}}}
         \RightLabel{(\textsc{T-Provide})}
-        \UnaryInfC{$\tjudgment{\context}{\parens{\eprovide{\scheme_2}{\evar}{\term_1}{\term_2}}}{\stwithx{\type}\rdiff{\row}{\rsingleton{\scheme_2}}}$}
+        \UnaryInfC{$\tjudgment{\context}{\parens{\eprovide{\type_2}{\evar}{\term_1}{\term_2}}}{\tptwithx{\properType}\rdiff{\row}{\rsingleton{\type_2}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\context}{\term}{\scheme_1}$}
-          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\tjudgment{\context}{\term}{\type_1}$}
+          \AxiomC{$\subtype{\type_1}{\type_2}$}
         \RightLabel{(\textsc{T-Subsumption})}
-        \BinaryInfC{$\tjudgment{\context}{\term}{\scheme_2}$}
+        \BinaryInfC{$\tjudgment{\context}{\term}{\type_2}$}
       \end{prooftree}
 
       \caption{Typing rules}\label{fig:typing_rules}
@@ -232,24 +232,24 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\tjudgment{\context}{\scheme}{\kind}$}
+        \framebox{$\tjudgment{\context}{\type}{\kind}$}
       \end{center}
 
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\context}{\scheme_1}{\ktype}$}
-          \AxiomC{$\tjudgment{\context}{\scheme_2}{\ktype}$}
+          \AxiomC{$\tjudgment{\context}{\type_1}{\ktype}$}
+          \AxiomC{$\tjudgment{\context}{\type_2}{\ktype}$}
           \AxiomC{$\tjudgment{\context}{\row}{\krow}$}
         \RightLabel{(\textsc{K-Arrow})}
-        \TrinaryInfC{$\tjudgment{\context}{\stwithx{\parens{\tarrow{\scheme_1}{\scheme_2}}}{\row}}{\ktype}$}
+        \TrinaryInfC{$\tjudgment{\context}{\tptwithx{\parens{\ptarrow{\type_1}{\type_2}}}{\row}}{\ktype}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\csextend{\context}{\anno{\svar}{\kind}}}{\scheme}{\ktype}$}
+          \AxiomC{$\tjudgment{\csextend{\context}{\anno{\tvar}{\kind}}}{\type}{\ktype}$}
           \AxiomC{$\tjudgment{\context}{\row}{\krow}$}
         \RightLabel{(\textsc{K-ForAll})}
-        \BinaryInfC{$\tjudgment{\context}{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme}}}{\row}}{\ktype}$}
+        \BinaryInfC{$\tjudgment{\context}{\tptwithx{\parens{\ptforall{\anno{\tvar}{\kind}}{\type}}}{\row}}{\ktype}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -259,9 +259,9 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\context}{\scheme_1}{\keffect{\svar}{\evar}{\scheme_2}}$}
+          \AxiomC{$\tjudgment{\context}{\type_1}{\keffect{\tvar}{\evar}{\type_2}}$}
         \RightLabel{(\textsc{K-SingletonEffectRow})}
-        \UnaryInfC{$\tjudgment{\context}{\rsingleton{\scheme_1}}{\krow}$}
+        \UnaryInfC{$\tjudgment{\context}{\rsingleton{\type_1}}{\krow}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -272,22 +272,22 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\anno{\svar}{\kind} \in \context$}
+          \AxiomC{$\anno{\tvar}{\kind} \in \context$}
         \RightLabel{(\textsc{K-Variable})}
-        \UnaryInfC{$\tjudgment{\context}{\svar}{\kind}$}
+        \UnaryInfC{$\tjudgment{\context}{\tvar}{\kind}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\csextend{\context}{\anno{\svar}{\kind_1}}}{\scheme}{\kind_2}$}
+          \AxiomC{$\tjudgment{\csextend{\context}{\anno{\tvar}{\kind_1}}}{\type}{\kind_2}$}
         \RightLabel{(\textsc{K-Abstraction})}
-        \UnaryInfC{$\tjudgment{\context}{\parens{\sabs{\anno{\svar}{\kind_1}}{\scheme}}}{\karrow{\anno{\svar}{\kind_1}}{\kind_2}}$}
+        \UnaryInfC{$\tjudgment{\context}{\parens{\tabs{\anno{\tvar}{\kind_1}}{\type}}}{\karrow{\anno{\tvar}{\kind_1}}{\kind_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\context}{\scheme_1}{\kind_1}$}
-          \AxiomC{$\tjudgment{\context}{\scheme_2}{\karrow{\anno{\svar}{\kind_1}}{\kind_2}}$}
+          \AxiomC{$\tjudgment{\context}{\type_1}{\kind_1}$}
+          \AxiomC{$\tjudgment{\context}{\type_2}{\karrow{\anno{\tvar}{\kind_1}}{\kind_2}}$}
         \RightLabel{(\textsc{K-Application})}
-        \BinaryInfC{$\tjudgment{\context}{\sapp{\scheme_2}{\scheme_1}}{\sub{\kind_2}{\svar}{\scheme_1}}$}
+        \BinaryInfC{$\tjudgment{\context}{\tapp{\type_2}{\type_1}}{\sub{\kind_2}{\tvar}{\type_1}}$}
       \end{prooftree}
 
       \caption{Kinding rules}\label{fig:kinding_rules}
@@ -297,28 +297,28 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\opwellformed{\scheme}{\svar}$}
+        \framebox{$\opwellformed{\type}{\tvar}$}
       \end{center}
 
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\opwellformed{\scheme_2}{\svar}$}
+          \AxiomC{$\opwellformed{\type_2}{\tvar}$}
         \RightLabel{(\textsc{WF-Arrow})}
-        \UnaryInfC{$\opwellformed{\stwithx{\parens{\tarrow{\scheme_1}{\scheme_2}}}{\row}}{\svar}$}
+        \UnaryInfC{$\opwellformed{\tptwithx{\parens{\ptarrow{\type_1}{\type_2}}}{\row}}{\tvar}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\opwellformed{\scheme}{\svar_2}$}
-          \AxiomC{$\svar_1 \neq \svar_2$}
+          \AxiomC{$\opwellformed{\type}{\tvar_2}$}
+          \AxiomC{$\tvar_1 \neq \tvar_2$}
         \RightLabel{(\textsc{WF-ForAll})}
-        \BinaryInfC{$\opwellformed{\stwithx{\parens{\tforall{\anno{\svar_1}{\kind}}{\scheme}}}{\row}}{\svar_2}$}
+        \BinaryInfC{$\opwellformed{\tptwithx{\parens{\ptforall{\anno{\tvar_1}{\kind}}{\type}}}{\row}}{\tvar_2}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\rsingleton{\svar}}{\row}$}
+          \AxiomC{$\subtype{\rsingleton{\tvar}}{\row}$}
         \RightLabel{(\textsc{WF-TypeWithEffects})}
-        \UnaryInfC{$\opwellformed{\stwithx{\type}{\row}}{\svar}$}
+        \UnaryInfC{$\opwellformed{\tptwithx{\properType}{\row}}{\tvar}$}
       \end{prooftree}
 
       \caption{Operation type well-formedness}\label{fig:operation_type_well_formedness}
@@ -328,7 +328,7 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\subtype{\scheme}{\scheme}$}
+        \framebox{$\subtype{\type}{\type}$}
       \end{center}
 
       \medskip
@@ -336,29 +336,29 @@
       \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{ST-Reflexivity})}
-        \UnaryInfC{$\subtype{\scheme}{\scheme}$}
+        \UnaryInfC{$\subtype{\type}{\type}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
-          \AxiomC{$\subtype{\scheme_2}{\scheme_3}$}
+          \AxiomC{$\subtype{\type_1}{\type_2}$}
+          \AxiomC{$\subtype{\type_2}{\type_3}$}
         \RightLabel{(\textsc{ST-Transitivity})}
-        \BinaryInfC{$\subtype{\scheme_1}{\scheme_3}$}
+        \BinaryInfC{$\subtype{\type_1}{\type_3}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\scheme_3}{\scheme_1}$}
-          \AxiomC{$\subtype{\scheme_2}{\scheme_4}$}
+          \AxiomC{$\subtype{\type_3}{\type_1}$}
+          \AxiomC{$\subtype{\type_2}{\type_4}$}
           \AxiomC{$\subtype{\row_1}{\row_2}$}
         \RightLabel{(\textsc{ST-Arrow})}
-        \TrinaryInfC{$\subtype{\stwithx{\parens{\tarrow{\scheme_1}{\scheme_2}}}{\row_1}}{\stwithx{\parens{\tarrow{\scheme_3}{\scheme_4}}}{\row_2}}$}
+        \TrinaryInfC{$\subtype{\tptwithx{\parens{\ptarrow{\type_1}{\type_2}}}{\row_1}}{\tptwithx{\parens{\ptarrow{\type_3}{\type_4}}}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\subtype{\type_1}{\type_2}$}
           \AxiomC{$\subtype{\row_1}{\row_2}$}
         \RightLabel{(\textsc{ST-ForAll})}
-        \BinaryInfC{$\subtype{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme_1}}}{\row_1}}{\stwithx{\parens{\tforall{\anno{\svar}{\kind}}{\scheme_2}}}{\row_2}}$}
+        \BinaryInfC{$\subtype{\tptwithx{\parens{\ptforall{\anno{\tvar}{\kind}}{\type_1}}}{\row_1}}{\tptwithx{\parens{\ptforall{\anno{\tvar}{\kind}}{\type_2}}}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -368,9 +368,9 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
+          \AxiomC{$\subtype{\type_1}{\type_2}$}
         \RightLabel{(\textsc{ST-Singleton})}
-        \UnaryInfC{$\subtype{\rsingleton{\scheme_1}}{\rsingleton{\scheme_2}}$}
+        \UnaryInfC{$\subtype{\rsingleton{\type_1}}{\rsingleton{\type_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -393,15 +393,15 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
-        \RightLabel{(\textsc{ST-SchemeAbstraction})}
-        \UnaryInfC{$\subtype{\sabs{\anno{\svar}{\kind}}{\scheme_1}}{\sabs{\anno{\svar}{\kind}}{\scheme_2}}$}
+          \AxiomC{$\subtype{\type_1}{\type_2}$}
+        \RightLabel{(\textsc{ST-TypeAbstraction})}
+        \UnaryInfC{$\subtype{\tabs{\anno{\tvar}{\kind}}{\type_1}}{\tabs{\anno{\tvar}{\kind}}{\type_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\scheme_1}{\scheme_2}$}
-        \RightLabel{(\textsc{ST-SchemeApplication})}
-        \UnaryInfC{$\subtype{\sapp{\scheme_1}{\scheme_3}}{\sapp{\scheme_2}{\scheme_3}}$}
+          \AxiomC{$\subtype{\type_1}{\type_2}$}
+        \RightLabel{(\textsc{ST-TypeApplication})}
+        \UnaryInfC{$\subtype{\tapp{\type_1}{\type_3}}{\tapp{\type_2}{\type_3}}$}
       \end{prooftree}
 
       \caption{Subtyping}\label{fig:subtyping}


### PR DESCRIPTION
Inline effect row subsumption into the subtyping rules. I also did a big refactoring to rename "scheme" to "type" everywhere. These two changes are separate commits.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subtyping-rows.pdf) is a link to the PDF generated from this PR.
