### PR TITLE
Merge the effect row subsumptions rules into the subtyping rules

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -34,35 +34,8 @@ with opTypeWellFormed : type -> typeId -> Prop :=
     opTypeWellFormed (tptwithx (ptforall a1 k t) r) a2
 | wfTWithEff :
     forall a r t,
-    subsumes (rsingleton (tvar a)) r ->
+    subtype (trow (rsingleton (tvar a))) (trow r) ->
     opTypeWellFormed (tptwithx t r) a
-
-(* Effect row subsumption *)
-
-with subsumes : row -> row -> Prop :=
-| rTrans :
-    forall r1 r2 r3,
-    subsumes r1 r2 ->
-    subsumes r2 r3 ->
-    subsumes r1 r3
-| rEmpty:
-    forall r1,
-    subsumes rempty r1
-| rSingleton :
-    forall t1 t2,
-    subtype t1 t2 ->
-    subsumes (rsingleton t1) (rsingleton t2)
-| rUnion :
-    forall r1 r2 r3,
-    subsumes r1 r3 ->
-    subsumes r2 r3 ->
-    subsumes (runion r1 r2) r3
-| rWeaken :
-    forall r1 r2,
-    subsumes r1 (runion r1 r2)
-| rExchange :
-    forall r1 r2,
-    subsumes (runion r1 r2) (runion r2 r1)
 
 (* Subtyping *)
 
@@ -79,13 +52,31 @@ with subtype : type -> type -> Prop :=
     forall t1 t2 t3 t4 r1 r2,
     subtype t3 t1 ->
     subtype t2 t4 ->
-    subsumes r1 r2 ->
+    subtype (trow r1) (trow r2) ->
     subtype (tptwithx (ptarrow t1 t2) r1) (tptwithx (ptarrow t3 t4) r2)
 | stForAll :
     forall t1 t2 r1 r2 a k,
     subtype t1 t2 ->
-    subsumes r1 r2 ->
+    subtype (trow r1) (trow r2) ->
     subtype (tptwithx (ptforall a k t1) r1) (tptwithx (ptforall a k t2) r2)
+| stEmpty:
+    forall r,
+    subtype (trow rempty) (trow r)
+| stSingleton :
+    forall t1 t2,
+    subtype t1 t2 ->
+    subtype (trow (rsingleton t1)) (trow (rsingleton t2))
+| stUnion :
+    forall r1 r2 t,
+    subtype (trow r1) t ->
+    subtype (trow r2) t ->
+    subtype (trow (runion r1 r2)) t
+| stWeaken :
+    forall r1 r2,
+    subtype (trow r1) (trow (runion r1 r2))
+| stExchange :
+    forall r1 r2,
+    subtype (trow (runion r1 r2)) (trow (runion r2 r1))
 | stTypeAbs :
     forall t1 t2 a k,
     subtype t1 t2 ->

--- a/formalization/subsumption.v
+++ b/formalization/subsumption.v
@@ -1,40 +1,26 @@
 Require Import syntax.
 Require Import judgments.
 
-Theorem rRefl : forall r, subsumes r r.
-Proof.
-  intros.
-  induction r.
-  - apply rEmpty.
-  - apply rSingleton.
-    apply stRefl.
-  - apply rUnion.
-    + apply rWeaken.
-    + apply rTrans with (r2 := runion r2 r1).
-      * apply rWeaken.
-      * apply rExchange.
-Qed.
-
-Theorem rAssoc :
+Theorem stAssoc :
   forall r1 r2 r3,
-  subsumes (runion (runion r1 r2) r3) (runion r1 (runion r2 r3)).
+  subtype (trow (runion (runion r1 r2) r3)) (trow (runion r1 (runion r2 r3))).
 Proof.
   intros.
-  apply rUnion.
-  - apply rUnion.
-    + apply rWeaken.
-    + apply rTrans with (r2 := runion (runion r2 r3) r1).
-      * apply rTrans with (r2 := runion r2 r3); apply rWeaken.
-      * apply rExchange.
-  - apply rTrans with (r2 := runion (runion r2 r3) r1).
-    + apply rTrans with (r2 := runion r2 r3).
+  apply stUnion.
+  - apply stUnion.
+    + apply stWeaken.
+    + apply stTrans with (t2 := trow (runion (runion r2 r3) r1)).
+      * apply stTrans with (t2 := trow (runion r2 r3)); apply stWeaken.
+      * apply stExchange.
+  - apply stTrans with (t2 := trow (runion (runion r2 r3) r1)).
+    + apply stTrans with (t2 := trow (runion r2 r3)).
       * {
-        apply rTrans with (r2 := runion r3 r2).
-        - apply rWeaken.
-        - apply rExchange.
+        apply stTrans with (t2 := trow (runion r3 r2)).
+        - apply stWeaken.
+        - apply stExchange.
       }
-      * apply rWeaken.
-    + apply rExchange.
+      * apply stWeaken.
+    + apply stExchange.
 Qed.
 
 Inductive rowContains : row -> type -> Prop :=
@@ -50,78 +36,157 @@ Inductive rowContains : row -> type -> Prop :=
     rowContains r2 t ->
     rowContains (runion r1 r2) t.
 
-Definition containment r1 r2 :=
+Definition subset r1 r2 :=
   forall t1,
   rowContains r1 t1 ->
   exists t2,
   (subtype t1 t2 /\ rowContains r2 t2).
 
-Lemma subsumptionImpliesContainment :
-  forall r1 r2,
-  subsumes r1 r2 ->
-  containment r1 r2.
+Lemma subsetTrans :
+  forall r1 r2 r3,
+  subset r1 r2 ->
+  subset r2 r3 ->
+  subset r1 r3.
 Proof.
-  intros r1 r2 H.
-  unfold containment.
+  intros.
+  unfold subset in *.
+  intros.
+  set (H2 := H t1 H1).
+  destruct H2.
+  destruct H2.
+  set (H4 := H0 x H3).
+  destruct H4.
+  destruct H4.
+  exists x0.
+  split.
+  - apply stTrans with (t2 := x); auto.
+  - auto.
+Qed.
+
+Lemma rownessClosedUnderSubtype :
+  forall t1 t2,
+  subtype t1 t2 ->
+  forall r1,
+  t1 = trow r1 ->
+  exists r2,
+  t2 = trow r2.
+Proof.
+  intros t1 t2 H.
   induction H.
-  (* rTrans *)
+  (* stRefl *)
   - intros.
-    destruct IHsubsumes1 with (t1 := t1).
-    + auto.
-    + elim H2. intros.
-      destruct IHsubsumes2 with (t1 := x).
-      * auto.
-      * {
-        elim H5. intros.
-        exists x0.
-        split.
-        - apply stTrans with (t2 := x); auto.
-        - auto.
-      }
-  (* rEmpty *)
+    exists r1.
+    auto.
+  (* stTrans *)
   - intros.
-    exists t1.
-    inversion H.
-  (* rSingleton *)
+    set (H2 := IHsubtype1 r1 H1).
+    destruct H2.
+    set (H3 := IHsubtype2 x H2).
+    auto.
+  (* stArrow *)
   - intros.
-    exists t2.
-    intros.
-    inversion H0.
-    assert (subtype t0 t2).
-    + apply stTrans with (t2 := t1).
-      * rewrite H1.
-        apply stRefl.
-      * auto.
-    + split.
-      * auto.
-      * apply rcSingleton.
-  (* rUnion *)
+    inversion H2.
+  (* stForAll *)
   - intros.
     inversion H1.
-    + destruct IHsubsumes1 with (t1 := t1).
-      * auto.
-      * exists x.
-        auto.
-    + destruct IHsubsumes2 with (t1 := t1).
-      * auto.
-      * exists x.
-        auto.
-  (* rWeaken *)
+  (* stEmpty *)
   - intros.
+    exists r.
+    reflexivity.
+  (* stSingleton *)
+  - intros.
+    exists (rsingleton t2).
+    reflexivity.
+  (* stUnion *)
+  - intros.
+    set (H2 := IHsubtype1 r1 eq_refl).
+    destruct H2.
+    exists x.
+    auto.
+  (* stWeaken *)
+  - intros.
+    exists (runion r1 r2).
+    reflexivity.
+  (* stExchange *)
+  - intros.
+    exists (runion r2 r1).
+    reflexivity.
+  (* stTypeAbs *)
+  - intros.
+    inversion H0.
+  (* stTypeApp *)
+  - intros.
+    inversion H0.
+Qed.
+
+Lemma subtypeImpliesSubsetAux :
+  forall t1 t2,
+  subtype t1 t2 ->
+  match t1 with
+  | trow r1 => match t2 with
+               | trow r2 => subset r1 r2
+               | _ => True
+               end
+  | _ => True
+  end.
+Proof.
+  intros.
+  induction H; auto.
+  (* stRefl *)
+  - destruct t; auto.
+    unfold subset.
+    intros.
+    exists t1.
+    split.
+    + apply stRefl.
+    + auto.
+  (* stTrans *)
+  - induction t1; auto.
+    assert (exists r2, t2 = trow r2).
+    + apply rownessClosedUnderSubtype with (t1 := trow r) (t2 := t2) (r1 := r); auto.
+    + destruct H1.
+      rewrite H1 in IHsubtype1.
+      rewrite H1 in IHsubtype2.
+      induction t3; auto.
+      apply subsetTrans with (r2 := x); auto.
+  (* stEmpty *)
+  - unfold subset.
+    intros.
     exists t1.
     split.
     + apply stRefl.
     + inversion H.
-      * apply rcUnionLeft.
-        apply rcSingleton.
-      * rewrite H1.
-        apply rcUnionLeft.
-        auto.
-      * rewrite H1.
-        apply rcUnionLeft.
-        auto.
-  (* rExchange *)
-  - intros.
+  (* stSingleton *)
+  - unfold subset.
+    intros.
+    exists t2.
+    inversion H0.
+    split.
+    + rewrite H1 in H.
+      auto.
+    + apply rcSingleton.
+  (* stUnion *)
+  - destruct t; auto.
+    unfold subset.
+    intros.
+    unfold subset in IHsubtype1.
+    unfold subset in IHsubtype2.
+    inversion H1.
+    + set (H6 := IHsubtype1 t1 H5).
+      auto.
+    + set (H6 := IHsubtype2 t1 H5).
+      auto.
+  (* stWeaken *)
+  - unfold subset.
+    intros.
+    exists t1.
+    split.
+    + apply stRefl.
+    + apply rcUnionLeft.
+      auto.
+  (* stExchange *)
+  - unfold subset.
+    intros.
     exists t1.
     split.
     + apply stRefl.
@@ -132,37 +197,47 @@ Proof.
         auto.
 Qed.
 
-Lemma containmentImpliesSubsumption :
+Lemma subtypeImpliesSubset :
   forall r1 r2,
-  containment r1 r2 ->
-  subsumes r1 r2.
+  subtype (trow r1) (trow r2) ->
+  subset r1 r2.
 Proof.
   intros.
-  unfold containment in H.
+  apply (subtypeImpliesSubsetAux (trow r1) (trow r2)).
+  auto.
+Qed.
+
+Lemma subsetImpliesSubtype :
+  forall r1 r2,
+  subset r1 r2 ->
+  subtype (trow r1) (trow r2).
+Proof.
+  intros.
+  unfold subset in H.
   induction r1.
   (* rempty *)
-  - apply rEmpty.
+  - apply stEmpty.
   (* rsingleton *)
   - induction r2.
     (* rempty *)
     + set (H1 := H t).
       set (H2 := H1 (rcSingleton t)).
-      elim H2. intros.
-      elim H0. intros.
-      inversion H4.
+      destruct H2.
+      destruct H0.
+      inversion H2.
     (* rsingleton *)
     + set (H1 := H t).
       set (H2 := H1 (rcSingleton t)).
-      elim H2. intros.
-      elim H0. intros.
-      inversion H4.
-      apply rSingleton. auto.
+      destruct H2.
+      destruct H0.
+      inversion H2.
+      apply stSingleton. auto.
     (* runion *)
     + set (H1 := H t).
       set (H2 := H1 (rcSingleton t)).
-      elim H2. intros.
-      elim H0. intros.
-      inversion H4.
+      destruct H2.
+      destruct H0.
+      inversion H2.
       * {
         assert (
           forall t1 : type,
@@ -172,12 +247,12 @@ Proof.
         ).
         - intros.
           exists x.
-          inversion H9.
-          rewrite H10 in H3. auto.
-        - apply IHr2_1 in H9.
-          assert (subsumes r2_1 (runion r2_1 r2_2)).
-          + apply rWeaken.
-          + apply rTrans with (r2 := r2_1); auto.
+          inversion H7.
+          rewrite H8 in H0. auto.
+        - apply IHr2_1 in H7.
+          assert (subtype (trow r2_1) (trow (runion r2_1 r2_2))).
+          + apply stWeaken.
+          + apply stTrans with (t2 := trow r2_1); auto.
       }
       * {
         assert (
@@ -188,14 +263,14 @@ Proof.
         ).
         - intros.
           exists x.
-          inversion H9.
-          rewrite H10 in H3. auto.
-        - apply IHr2_2 in H9.
-          assert (subsumes r2_2 (runion r2_1 r2_2)).
-          + apply rTrans with (r2 := runion r2_2 r2_1).
-            * apply rWeaken.
-            * apply rExchange.
-          + apply rTrans with (r2 := r2_2); auto.
+          inversion H7.
+          rewrite H8 in H0. auto.
+        - apply IHr2_2 in H7.
+          assert (subtype (trow r2_2) (trow (runion r2_1 r2_2))).
+          + apply stTrans with (t2 := trow (runion r2_2 r2_1)).
+            * apply stWeaken.
+            * apply stExchange.
+          + apply stTrans with (t2 := trow r2_2); auto.
       }
   (* runion *)
   - assert (
@@ -224,15 +299,15 @@ Proof.
         - set (H4 := H2 H3).
           auto.
       }
-      * apply rUnion; auto.
+      * apply stUnion; auto.
 Qed.
 
-Theorem subsumptionCorrect :
+Theorem subtypeCorrect :
   forall r1 r2,
-  subsumes r1 r2 <->
-  containment r1 r2.
+  subtype (trow r1) (trow r2) <->
+  subset r1 r2.
 Proof.
   split.
-  - apply subsumptionImpliesContainment.
-  - apply containmentImpliesSubsumption.
+  - apply subtypeImpliesSubset.
+  - apply subsetImpliesSubtype.
 Qed.

--- a/main.tex
+++ b/main.tex
@@ -19,17 +19,21 @@
 %%%%%%%%%%%%
 
 \usepackage[colorlinks]{hyperref}
+\usepackage[framemethod=tikz]{mdframed} % The `tikz` thing allows us to have a transparent background
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{bussproofs}
 \usepackage{mathtools}
-\usepackage[framemethod=tikz]{mdframed} % The `tikz` thing allows us to have a transparent background
 \usepackage{stackengine} % For stacking axioms
 \usepackage{stmaryrd} % For \llbracket and \rrbracket
 
 %%%%%%%%%%
 % Macros %
 %%%%%%%%%%
+
+% Theorem styles
+\newtheorem{definition}{Definition}
+\newtheorem{theorem}{Theorem}
 
 % Misc
 \newcommand\anno[2]{#1 : #2} % chktex 26
@@ -407,4 +411,22 @@
       \caption{Subtyping}\label{fig:subtyping}
     \end{mdframed}
   \end{figure}
+
+  \begin{definition}[Effect row membership]
+    Let $\type \in \row$ be the smallest relation satisfying
+    \begin{enumerate}
+      \item $\type \in \rsingleton{\type}$
+      \item if $\type \in \row_1$ then $\type \in \runion{\row_1}{\row_2}$
+      \item if $\type \in \row_2$ then $\type \in \runion{\row_1}{\row_2}$.
+    \end{enumerate}
+  \end{definition}
+
+  \begin{theorem}[Effect row subtyping]
+    Given any two effect rows $\row_1, \row_2$, the following are equivalent:
+    \begin{enumerate}
+      \item $\subtype{\row_1}{\row_2}$
+      \item $\forall \type_1 \;.\; \type_1 \in \row_1$ implies $\exists \type_2 \;.\; \subtype{\type_1}{\type_2}$ and $\type_2 \in \row_2$.
+    \end{enumerate}
+  \end{theorem}
+
 \end{document}


### PR DESCRIPTION
Merge the effect row subsumptions rules into the subtyping rules and re-prove everything.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-remove-subsumption.pdf) is a link to the PDF generated from this PR.
