### PR TITLE
Add beta reduction to subtyping

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -404,8 +404,22 @@
 
       \begin{prooftree}
           \AxiomC{$\subtype{\type_1}{\type_2}$}
+          \AxiomC{$\subtype{\type_3}{\type_4}$}
+          \AxiomC{$\subtype{\type_4}{\type_3}$}
         \RightLabel{(\textsc{ST-TypeApplication})}
-        \UnaryInfC{$\subtype{\tapp{\type_1}{\type_3}}{\tapp{\type_2}{\type_3}}$}
+        \TrinaryInfC{$\subtype{\tapp{\type_1}{\type_3}}{\tapp{\type_2}{\type_4}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Beta1})}
+        \UnaryInfC{$\subtype{\tapp{\parens{\tabs{\anno{\tvar}{\kind}}{\type_1}}}{\type_2}}{\sub{\type_1}{\tvar}{\type_2}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Beta2})}
+        \UnaryInfC{$\subtype{\sub{\type_1}{\tvar}{\type_2}}{\tapp{\parens{\tabs{\anno{\tvar}{\kind}}{\type_1}}}{\type_2}}$}
       \end{prooftree}
 
       \caption{Subtyping}\label{fig:subtyping}


### PR DESCRIPTION
Add beta reduction and update `ST-TypeApplication` to check for equivalence of the parameters. This will relate `Num Int` and `Num ((\a : * . a) Int)` under subtyping.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-beta-reduction-subtyping.pdf) is a link to the PDF generated from this PR.
