### PR TITLE
Make htProvide remove the provided effect

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -66,7 +66,9 @@ Inductive hasType : context -> term -> type -> Prop :=
     hasType c e2 (tptwithr pt r1) ->
     hasKind c t2 (keffect a x t3) ->
     subtype t1 (substTypeInType t3 a t2) ->
-    (* TODO: ensure that r2 = r1 - {t2} *)
+    ~(rowContains r2 t2) ->
+    subtype (trow (runion (rsingleton t2) r2)) (trow r1) ->
+    subtype (trow r1) (trow (runion (rsingleton t2) r2)) ->
     hasType c (eprovide t2 x e1 e2) (tptwithr pt r2)
 | htSub :
     forall c e t1 t2,


### PR DESCRIPTION
I don't really like that `htProvide` uses both `subtype` and `rowContains`, but `~ subtype` doesn't work because of Coq's restriction requiring strictly positive occurrences of `subtype`. What do you think?

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-fix-htprovide.pdf) is a link to the PDF generated from this PR.
