### PR TITLE
Replace ST-Exchange with ST-WeakenRight

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -142,9 +142,9 @@ with subtype : type -> type -> Prop :=
     subtype (trow r1) t ->
     subtype (trow r2) t ->
     subtype (trow (runion r1 r2)) t
-| stWeaken :
+| stWeakenLeft :
     forall r1 r2,
     subtype (trow r1) (trow (runion r1 r2))
-| stExchange :
+| stWeakenRight :
     forall r1 r2,
-    subtype (trow (runion r1 r2)) (trow (runion r2 r1)).
+    subtype (trow r2) (trow (runion r1 r2)).

--- a/formalization/subtyping.v
+++ b/formalization/subtyping.v
@@ -1,6 +1,16 @@
 Require Import syntax.
 Require Import judgments.
 
+Theorem stExchange :
+  forall r1 r2,
+  subtype (trow (runion r1 r2)) (trow (runion r2 r1)).
+Proof.
+  intros r1 r2.
+  apply stUnion.
+  - apply stWeakenRight.
+  - apply stWeakenLeft.
+Qed.
+
 Theorem stAssoc :
   forall r1 r2 r3,
   subtype (trow (runion (runion r1 r2) r3)) (trow (runion r1 (runion r2 r3))).
@@ -8,19 +18,11 @@ Proof.
   intros r1 r2 r3.
   apply stUnion.
   - apply stUnion.
-    + apply stWeaken.
-    + apply stTrans with (t2 := trow (runion (runion r2 r3) r1)).
-      * apply stTrans with (t2 := trow (runion r2 r3)); apply stWeaken.
-      * apply stExchange.
-  - apply stTrans with (t2 := trow (runion (runion r2 r3) r1)).
+    + apply stWeakenLeft.
     + apply stTrans with (t2 := trow (runion r2 r3)).
-      * {
-        apply stTrans with (t2 := trow (runion r3 r2)).
-        - apply stWeaken.
-        - apply stExchange.
-      }
-      * apply stWeaken.
-    + apply stExchange.
+      * apply stWeakenLeft.
+      * apply stWeakenRight.
+  - apply stTrans with (t2 := trow (runion r2 r3)); apply stWeakenRight.
 Qed.
 
 Definition subset r1 r2 :=
@@ -66,7 +68,7 @@ Proof.
     r1                                  | (* stEmpty *)
     t1 t2 H1 H2                         | (* stSingleton *)
     t1 r1 r2 H1 H2 H3 H4                | (* stUnion *)
-    r1 r2                               | (* stWeaken *)
+    r1 r2                               | (* stWeakenLeft *)
     r1 r2                                 (* stExchange *)
   ].
   (* stRefl *)
@@ -96,13 +98,13 @@ Proof.
     destruct H6 as [r4 H6].
     exists r4.
     auto.
-  (* stWeaken *)
+  (* stWeakenLeft *)
   - intros r3 H1.
     exists (runion r1 r2).
     reflexivity.
-  (* stExchange *)
+  (* stWeakenRight *)
   - intros r3 H1.
-    exists (runion r2 r1).
+    exists (runion r1 r2).
     reflexivity.
 Qed.
 
@@ -125,7 +127,7 @@ Proof.
     r1                                  | (* stEmpty *)
     t1 t2 H1 H2                         | (* stSingleton *)
     t1 r1 r2 H1 H2 H3 H4                | (* stUnion *)
-    r1 r2                               | (* stWeaken *)
+    r1 r2                               | (* stWeakenLeft *)
     r1 r2                                 (* stExchange *)
   ]; auto.
   (* stRefl *)
@@ -193,7 +195,7 @@ Proof.
       auto.
     + set (H9 := H4 t1 H6).
       auto.
-  (* stWeaken *)
+  (* stWeakenLeft *)
   - unfold subset.
     intros t1 H1.
     exists t1.
@@ -201,17 +203,14 @@ Proof.
     + apply stRefl.
     + apply rcUnionLeft.
       auto.
-  (* stExchange *)
+  (* stWeakenRight *)
   - unfold subset.
     intros t1 H1.
     exists t1.
     split.
     + apply stRefl.
-    + inversion H1.
-      * apply rcUnionRight.
-        auto.
-      * apply rcUnionLeft.
-        auto.
+    + apply rcUnionRight.
+      auto.
 Qed.
 
 Lemma subtypeImpliesSubset :
@@ -283,7 +282,7 @@ Proof.
           rewrite H12 in H5. auto.
         - apply H2 in H10.
           assert (subtype (trow r1) (trow (runion r1 r3))).
-          + apply stWeaken.
+          + apply stWeakenLeft.
           + apply stTrans with (t2 := trow r1); auto.
       }
       * {
@@ -304,7 +303,7 @@ Proof.
         - apply H3 in H0.
           assert (subtype (trow r3) (trow (runion r1 r3))).
           + apply stTrans with (t2 := trow (runion r3 r1)).
-            * apply stWeaken.
+            * apply stWeakenLeft.
             * apply stExchange.
           + apply stTrans with (t2 := trow r3); auto.
       }

--- a/main.tex
+++ b/main.tex
@@ -410,14 +410,14 @@
 
       \begin{prooftree}
           \AxiomC{}
-        \RightLabel{(\textsc{ST-Weakening})}
+        \RightLabel{(\textsc{ST-WeakeningLeft})}
         \UnaryInfC{$\subtype{\row_1}{\runion{\row_1}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{}
-        \RightLabel{(\textsc{ST-Exchange})}
-        \UnaryInfC{$\subtype{\runion{\row_1}{\row_2}}{\runion{\row_2}{\row_1}}$}
+        \RightLabel{(\textsc{ST-WeakeningRight})}
+        \UnaryInfC{$\subtype{\row_2}{\runion{\row_1}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
Replace the `ST-Exchange` axiom with `ST-WeakenRight`, and add `ST-Exchange` back as a theorem. Do you think we should do this, or keep `ST-Exchange` as an axiom?

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-weaken-right.pdf) is a link to the PDF generated from this PR.
