### PR TITLE
Allow variable shadowing and simplify the typing rules

### DIFF
--- a/formalization/helpers.v
+++ b/formalization/helpers.v
@@ -19,8 +19,7 @@ Proof.
       intros H2.
       inversion H2.
       contradiction.
-    + apply right.
-      auto.
+    + auto.
 Qed.
 
 Fixpoint lookupEVar c1 e :=

--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -30,7 +30,6 @@ Inductive hasType : context -> term -> type -> Prop :=
     forall e x t1 t2 c,
     hasType (ceextend c x t1) e t2 ->
     hasKind c t1 ktype ->
-    lookupEVar c (evar x) = None ->
     hasType c (eabs x t1 e) (tptwithr (ptarrow t1 t2) rempty)
 | htAppByV :
     forall e1 e2 pt1 pt2 pt3 r1 r2 r3 r4 c,
@@ -49,8 +48,6 @@ Inductive hasType : context -> term -> type -> Prop :=
     opTypeWellFormed t1 a3 ->
     hasKind (ctextend c a3 (keffect a3 x t1)) t1 ktype ->
     occursInType a1 t2 = false ->
-    lookupTVar c (tvar a1) = None ->
-    lookupEVar c (evar x) = None ->
     hasType (
       ceextend (ctextend c a1 (keffect a3 x t1)) x t1
     ) e t2 ->

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -86,6 +86,7 @@
 \newcommand\cempty{\varnothing_{\context}}
 \newcommand\ceextend[2]{#1, #2}
 \newcommand\csextend[2]{#1, #2}
+\newcommand\clookup[2]{#1\parens{#2}}
 
 % Judgements
 \newcommand\tjudgment[3]{#1 \vdash \anno{#2}{#3}} % chktex 1
@@ -170,7 +171,7 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\anno{\evar}{\type} \in \context$}
+          \AxiomC{$\clookup{\context}{\evar} = \type$}
         \RightLabel{(\textsc{T-Variable})}
         \UnaryInfC{$\tjudgment{\context}{\evar}{\type}$}
       \end{prooftree}
@@ -178,9 +179,8 @@
       \begin{prooftree}
           \AxiomC{$\tjudgment{\ceextend{\context}{\anno{\evar}{\type_1}}}{\term}{\type_2}$}
           \AxiomC{$\tjudgment{\context}{\type_1}{\ktype}$}
-          \AxiomC{$\evar \notin \dom{\context}$}
         \RightLabel{(\textsc{T-Abstraction})}
-        \TrinaryInfC{$\tjudgment{\context}{\parens{\eabs{\anno{\evar}{\type_1}}{\term}}}{\tptwithr{\parens{\ptarrow{\type_1}{\type_2}}}}{\rempty}$}
+        \BinaryInfC{$\tjudgment{\context}{\parens{\eabs{\anno{\evar}{\type_1}}{\term}}}{\tptwithr{\parens{\ptarrow{\type_1}{\type_2}}}}{\rempty}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -202,9 +202,8 @@
       \begin{prooftree}
         \color{red}
           \AxiomC{$\tjudgment{\csextend{\context}{\anno{\tvar}{\kind}}}{\term}{\type}$}
-          \AxiomC{$\tvar \notin \dom{\context}$}
         \RightLabel{(\textsc{T-TypeAbstraction})}
-        \BinaryInfC{$\tjudgment{\context}{\parens{\etabs{\anno{\tvar}{\kind}}{\term}}}{\tptwithr{\parens{\ptforall{\anno{\tvar}{\kind}}{\type}}}}{\rempty}$}
+        \UnaryInfC{$\tjudgment{\context}{\parens{\etabs{\anno{\tvar}{\kind}}{\term}}}{\tptwithr{\parens{\ptforall{\anno{\tvar}{\kind}}{\type}}}}{\rempty}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -217,10 +216,8 @@
 
       \begin{prooftree}
           \AxiomC{\Shortstack[c]{{$\opwellformed{\type_1}{\tvar_3}$}
-            {$\tjudgment{\csextend{\csextend{\context}{\lstof{\color{red} \anno{\tvar_2^i}{\kind^i}}}}{\anno{\tvar_3}{\keffect{\tvar_3}{\evar}{\type_1}}}}{\type_1}{\ktype}$}
             {$\tvar_1 \notin \type_2$}
-            {$\tvar_1 \notin \dom{\context}$}
-            {$\evar \notin \dom{\context}$}
+            {$\tjudgment{\csextend{\csextend{\context}{\lstof{\color{red} \anno{\tvar_2^i}{\kind^i}}}}{\anno{\tvar_3}{\keffect{\tvar_3}{\evar}{\type_1}}}}{\type_1}{\ktype}$}
             {$\tjudgment{\ceextend{\csextend{\context}{\anno{\tvar_1}{\karrow{\lstof{\color{red} \anno{\tvar_2^i}{\kind^i}}}{\keffect{\tvar_3}{\evar}{\type_1}}}}}{\anno{\evar}{\type_1}}}{\term}{\type_2}$}}}
         \RightLabel{(\textsc{T-Effect})}
         \UnaryInfC{$\tjudgment{\context}{\parens{\eeffect{\tvar_1}{\karrow{\lstof{\color{red} \anno{\tvar_2^i}{\kind^i}}}{\keffect{\tvar_3}{\evar}{\type_1}}}{\term}}}{\type_2}$}
@@ -296,7 +293,7 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\anno{\tvar}{\kind} \in \context$}
+          \AxiomC{$\clookup{\context}{\tvar} = \kind$}
         \RightLabel{(\textsc{K-Variable})}
         \UnaryInfC{$\tjudgment{\context}{\tvar}{\kind}$}
       \end{prooftree}


### PR DESCRIPTION
Allow variable shadowing and simplify the typing rules.

When [formalizing the STLC](https://github.com/stepchowfun/coq-fun/blob/master/coq/stlc.v), I realized it's actually more natural to allow variable shadowing than to forbid it. Previously our typing rules had to check that new variables being introduced into the context (e.g., by `T-Abstraction`) were not already in the context, but no other paper seems to do that. It seems more natural to be able to add any variable to the context at any time, and just have a smarter lookup function in rules like `T-Variable` which will select the most "recent" occurrence. I've seen this in other papers. This corresponds exactly to how we are formalizing it in Coq, and it also makes the typing rules simpler.

I also reordered the premises in `T-Effect` to make them look nicer.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-shadowing.pdf) is a link to the PDF generated from this PR.
