### PR TITLE
Various unrelated fixes

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -232,13 +232,6 @@
         \UnaryInfC{$\tjudgment{\context}{\parens{\eprovide{\type_2}{\evar}{\term_1}{\term_2}}}{\tptwithr{\properType}\rdiff{\row}{\rsingleton{\type_2}}}$}
       \end{prooftree}
 
-      \begin{prooftree}
-          \AxiomC{$\tjudgment{\context}{\term}{\type_1}$}
-          \AxiomC{$\subtype{\type_1}{\type_2}$}
-        \RightLabel{(\textsc{T-Subsumption})}
-        \BinaryInfC{$\tjudgment{\context}{\term}{\type_2}$}
-      \end{prooftree}
-
       \caption{Typing rules}\label{fig:typing_rules}
     \end{mdframed}
   \end{figure}
@@ -252,6 +245,7 @@
       \medskip
 
       \begin{prooftree}
+        \color{blue}
           \AxiomC{$\tjudgment{\context}{\row}{\krow}$}
         \RightLabel{(\textsc{K-Unit})}
         \UnaryInfC{$\tjudgment{\context}{\tptwithr{\ptunit}{\row}}{\ktype}$}
@@ -368,6 +362,13 @@
           \AxiomC{$\subtype{\type_2}{\type_3}$}
         \RightLabel{(\textsc{ST-Transitivity})}
         \BinaryInfC{$\subtype{\type_1}{\type_3}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+        \color{blue}
+          \AxiomC{$\subtype{\row_1}{\row_2}$}
+        \RightLabel{(\textsc{ST-Unit})}
+        \UnaryInfC{$\subtype{\tptwithr{\ptunit}{\row_1}}{\tptwithr{\ptunit}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
- Delete `T-Subsumption` because it's already (necessarily) inlined into the typing rules for applications.
- Make `K-Unit` the same color as `T-Unit` (blue, because it's only temporary? but maybe we should keep it permanently...).
- Add subtyping rule (`ST-Unit`) for the unit type, just like the one for arrows (not sure how we missed this).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-small-fixes.pdf) is a link to the PDF generated from this PR.
