### PR TITLE
Remove application by value

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -31,18 +31,12 @@ Inductive hasType : context -> term -> type -> Prop :=
     hasType (ceextend c x t1) e t2 ->
     hasKind c t1 ktype ->
     hasType c (eabs x t1 e) (tptwithr (ptarrow t1 t2) rempty)
-| htAppByV :
-    forall e1 e2 pt1 pt2 pt3 r1 r2 r3 r4 c,
-    hasType c e1 (tptwithr pt1 r1) ->
-    hasType c e2 (tptwithr (ptarrow (tptwithr pt2 r2) (tptwithr pt3 r3)) r4) ->
-    subtype (tptwithr pt1 rempty) (tptwithr pt2 r2) ->
-    hasType c (eappbv e2 e1) (tptwithr pt3 (runion (runion r1 r3) r4))
-| htAppByN :
+| htApp :
     forall e1 e2 pt1 pt2 pt3 r1 r2 r3 r4 c,
     hasType c e1 (tptwithr pt1 r1) ->
     hasType c e2 (tptwithr (ptarrow (tptwithr pt2 r2) (tptwithr pt3 r3)) r4) ->
     subtype (tptwithr pt1 r1) (tptwithr pt2 r2) ->
-    hasType c (eappbn e2 e1) (tptwithr pt3 (runion r3 r4))
+    hasType c (eapp e2 e1) (tptwithr pt3 (runion r3 r4))
 | htEffect :
     forall e x t1 t2 a1 a3 c,
     opTypeWellFormed t1 a3 ->

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -17,8 +17,7 @@ Inductive term : Type :=
 | eunit : term
 | evar : termId -> term
 | eabs : termId -> type -> term -> term
-| eappbv : term -> term -> term
-| eappbn : term -> term -> term
+| eapp : term -> term -> term
 | eeffect : typeId -> kind -> term -> term
 | eprovide : type -> termId -> term -> term -> term
 

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -62,8 +62,7 @@
 \newcommand\eunit{()}
 \newcommand\evar{x}
 \newcommand\eabs[2]{\lambda #1 \; . \; #2}
-\newcommand\eappbv[2]{#1 \; #2}
-\newcommand\eappbn[2]{#1 \left\llbracket #2 \right\rrbracket}
+\newcommand\eapp[2]{#1 \; #2}
 \newcommand\etabs[2]{\lambda #1 \; . \; #2}
 \newcommand\etapp[2]{#1 \; #2}
 \newcommand\eeffect[3]{\textbf{effect} \; \anno{#1}{#2} \; \textbf{in} \; #3}
@@ -149,8 +148,7 @@
           & $\eunit$ & unit \\
           & $\evar$ & variable \\
           & $\eabs{\anno{\evar}{\type}}{\term}$ & abstraction \\
-          & $\eappbv{\term}{\term}$ & application by value \\
-          & $\eappbn{\term}{\term}$ & application by name \\
+          & $\eapp{\term}{\term}$ & application \\
           & $\etabs{\tvar}{\term}$ & type abstraction \\
           & $\etapp{\term}{\type}$ & type application \\
           & $\eeffect{\evar}{\type}{\term}$ & effect declaration \\
@@ -210,17 +208,9 @@
       \begin{prooftree}
           \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\tptwithr{\properType_1}{\row_1}}$}
             {$\tjudgment{\context}{\term_2}{\tptwithr{\parens{\ptarrow{\tptwithr{\properType_2}{\row_2}}{\tptwithr{\properType_3}{\row_3}}}}{\row_4}}$}
-            {$\subtype{\context}{\tptwithr{\properType_1}{\rempty}}{\tptwithr{\properType_2}{\row_2}}$}}}
-        \RightLabel{(\textsc{T-ApplicationByValue})}
-        \UnaryInfC{$\tjudgment{\context}{\eappbv{\term_2}{\term_1}}{\tptwithr{\properType_3}{\runion{\runion{\row_1}{\row_3}}{\row_4}}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\tptwithr{\properType_1}{\row_1}}$}
-            {$\tjudgment{\context}{\term_2}{\tptwithr{\parens{\ptarrow{\tptwithr{\properType_2}{\row_2}}{\tptwithr{\properType_3}{\row_3}}}}{\row_4}}$}
             {$\subtype{\context}{\tptwithr{\properType_1}{\row_1}}{\tptwithr{\properType_2}{\row_2}}$}}}
-        \RightLabel{(\textsc{T-ApplicationByName})}
-        \UnaryInfC{$\tjudgment{\context}{\eappbn{\term_2}{\term_1}}{\tptwithr{\properType_3}{\runion{\row_3}{\row_4}}}$}
+        \RightLabel{(\textsc{T-Application})}
+        \UnaryInfC{$\tjudgment{\context}{\eapp{\term_2}{\term_1}}{\tptwithr{\properType_3}{\runion{\row_3}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
Remove application-by-value as a syntactic construct. It can be an ordinary value instead. This would be the type of that value:

```
strict : forall t1, t2, e1, e2, e3 .
         (t1 ! ∅ -> t2 ! e2) ! e3 ->
         t1 ! e1 -> t2 ! e1, e2, e3
```

**Note 1:** I think this function is impossible to define in our system, so it has to be a "built-in" value (e.g., provided by a standard library, just like Haskell's `seq`—which is not definable in Haskell).

**Note 2:** We can define Haskell's `seq` in terms of `strict`: `seq a b = strict (\x -> b) a`. I think the other direction is impossible: we can't define `strict` in terms of `seq`. So, `strict` is strictly more general than `seq`, pun intended.

Motivation:
- Simpler (and more conventional) syntax—finally we only have one form of application!
- Simpler type system (no more `T-ApplicationByValue`)
- The `strict` function can be partially applied, passed around as a first-class value, etc.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-remove-appbv.pdf) is a link to the PDF generated from this PR.
