### PR TITLE
Remove support for user-defined effects

### DIFF
--- a/formalization/judgments.v
+++ b/formalization/judgments.v
@@ -37,15 +37,6 @@ Inductive hasType : context -> term -> type -> Prop :=
     hasType c e2 (tptwithr (ptarrow (tptwithr pt2 r2) (tptwithr pt3 r3)) r4) ->
     subtype (tptwithr pt1 r1) (tptwithr pt2 r2) ->
     hasType c (eapp e2 e1) (tptwithr pt3 (runion r3 r4))
-| htEffect :
-    forall e x t1 t2 a1 a3 c,
-    opTypeWellFormed t1 a3 ->
-    hasKind (ctextend c a3 (keffect a3 x t1)) t1 ktype ->
-    occursInType a1 t2 = false ->
-    hasType (
-      ceextend (ctextend c a1 (keffect a3 x t1)) x t1
-    ) e t2 ->
-    hasType c (eeffect a1 (keffect a3 x t1) e) t2
 | htProvide :
     forall e1 e2 x pt t1 t2 t3 a r1 r2 c,
     hasType c e1 t1 ->

--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -18,7 +18,6 @@ Inductive term : Type :=
 | evar : termId -> term
 | eabs : termId -> type -> term -> term
 | eapp : term -> term -> term
-| eeffect : typeId -> kind -> term -> term
 | eprovide : type -> termId -> term -> term -> term
 
 (* Types *)

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -151,13 +151,12 @@
           & $\eapp{\term}{\term}$ & application \\
           & $\etabs{\tvar}{\term}$ & type abstraction \\
           & $\etapp{\term}{\type}$ & type application \\
-          & $\eeffect{\evar}{\type}{\term}$ & effect declaration \\
           & $\eprovide{\term}{\evar}{\term}{\term}$ & effect definition \\
           \\
           $\type \Coloneqq$ & & types: \\
           & $\tptwithr{\properType}{\row}$ & proper type with effects \\
           & $\tvar$ & type variable \\
-          & $\teffect{\evar}{\evar}{\type}$ & type of an effect \\
+          & $\row$ & effect row \\
           \\
           $\properType \Coloneqq$ & & proper types: \\
           & $\ptunit$ & unit type \\

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -225,14 +225,6 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\opwellformed{\context}{\type_1}{\evar_2}$}
-            {$\evar_1 \notin \freevars{\type_2}$}
-            {$\tjudgment{\ceextend{\csextend{\context}{\anno{\evar_1}{\tptwithr{\parens{\ptforall{\lstof{\tvar^i}}{\teffect{\evar_2}{\evar_3}{\type_1}}}}{\rempty}}}}{\anno{\evar_3}{\tptwithr{\parens{\ptforall{\lstof{\tvar^i}}{\sub{\type_1}{\evar_2}{\etapp{\evar_1}{\lstof{\tvar^i}}}}}}}{\rempty}}}{\term}{\type_2}$}}}
-        \RightLabel{(\textsc{T-Effect})}
-        \UnaryInfC{$\tjudgment{\context}{\parens{\eeffect{\evar_1}{\tptwithr{\parens{\ptforall{\lstof{\tvar^i} }{\teffect{\evar_2}{\evar_3}{\type_1}}}}{\rempty}}{\term}}}{\type_2}$}
-      \end{prooftree}
-
-      \begin{prooftree}
           \AxiomC{\Shortstack[c]{{$\tjudgment{\context}{\term_1}{\type_1}$}
             {$\tjudgment{\context}{\term_2}{\tptwithr{\properType}{\row}}$}
             {$\tjudgment{\context}{\term_3}{\teffect{\evar_2}{\evar_1}{\type_3}}$}


### PR DESCRIPTION
This PR also adds effect rows back to the syntax for types.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-remove-user-effects.pdf) is a link to the PDF generated from this PR.
