### PR TITLE
Introduce synonyms for \tau to enhance readability

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -67,13 +67,16 @@
 \newcommand\ecoprovide[3]{\textbf{coprovide} \; #1 \; \textbf{with} \; #2 \; \textbf{in} \; #3}
 
 % Types
-\newcommand\type{\tau}
+\newcommand\type{\phi}
+\newcommand\proper{\tau}
+\newcommand\row{\varepsilon}
+\newcommand\embellished{\sigma}
 \newcommand\tvar{\alpha}
 \newcommand\tembellished[3]{{#1}^{#2}_{#3}}
 \newcommand\tunit{1}
 \newcommand\tarrow[2]{#1 \rightarrow #2}
 \newcommand\tforall[2]{\forall #1 \; . \; #2}
-\newcommand\tempty{\varnothing_{\type}}
+\newcommand\tempty{\varnothing_{\row}}
 \newcommand\tsingleton[1]{\left\{ #1 \right\}}
 \newcommand\tunion[2]{#1, #2}
 \newcommand\tdiff[2]{#1 \; - \; #2}
@@ -90,7 +93,7 @@
 \newcommand\cextend[2]{#1, #2}
 
 % Effect map
-\newcommand\effect{\varepsilon}
+\newcommand\effect{e}
 \newcommand\effectmap{E}
 \newcommand\coeffectmap{\Delta}
 \newcommand\emempty{\varnothing_{\effectmap}}
@@ -149,22 +152,22 @@
           $\term \Coloneqq $ & & terms: \\
           & $\eunit$ & unit \\
           & $\evar$ & variable \\
-          & $\eabs{\anno{\evar}{\type}}{\term}$ & abstraction \\
+          & $\eabs{\anno{\evar}{\embellished}}{\term}$ & abstraction \\
           & $\eapp{\term}{\term}$ & application \\
           & $\etabs{\anno{\tvar}{\kind}}{\term}$ & type abstraction \\
-          & $\etapp{\term}{\type}$ & type application \\
+          & $\etapp{\term}{\embellished}$ & type application \\
           & $\eprovide{\effect}{\term}{\term}$ & effect definition \\
           & $\ecoprovide{\effect}{\term}{\term}$ & coeffect definition \\
           \\
-          $\type \Coloneqq$ & & types: \\
+          $\type, \proper, \row, \embellished \Coloneqq$ & & types: \\
           & $\tvar$ & type variable \\
-          & $\tembellished{\type}{\type}{\type}$ & embellished type \\
+          & $\tembellished{\proper}{\row}{\row}$ & embellished type \\
           & $\tunit$ & unit type \\
-          & $\tarrow{\type}{\type}$ & arrow type \\
-          & $\tforall{\anno{\tvar}{\kind}}{\type}$ & quantified type \\
+          & $\tarrow{\embellished}{\embellished}$ & arrow type \\
+          & $\tforall{\anno{\tvar}{\kind}}{\embellished}$ & quantified type \\
           & $\tempty$ & empty effect row \\
           & $\tsingleton{\effect}$ & singleton effect row \\
-          & $\tunion{\type}{\type}$ & effect row union \\
+          & $\tunion{\row}{\row}$ & effect row union \\
           \\
           $\kind \Coloneqq$ & & kinds: \\
           & $\kproper$ & kind of a proper type \\
@@ -173,16 +176,16 @@
           \\
           $\context \Coloneqq$ & & contexts: \\
           & $\cempty$ & empty context \\
-          & $\cextend{\context}{\anno{\evar}{\type}}$ & term variable binding \\
+          & $\cextend{\context}{\anno{\evar}{\embellished}}$ & term variable binding \\
           & $\cextend{\context}{\anno{\tvar}{\kind}}$ & type variable binding \\
           \\
           $\effectmap \Coloneqq$ & & effect map: \\
           & $\emempty$ & empty effect map \\
-          & $\emextend{\effectmap}{\emmap{\effect}{\anno{\evar}{\type}}}$ & effect binding \\
+          & $\emextend{\effectmap}{\emmap{\effect}{\anno{\evar}{\embellished}}}$ & effect binding \\
           \\
           $\coeffectmap \Coloneqq$ & & coeffect map: \\
           & $\ecomempty$ & empty coeffect map \\
-          & $\emextend{\coeffectmap}{\emmap{\effect}{\anno{\evar}{\type}}}$ & coeffect binding \\
+          & $\emextend{\coeffectmap}{\emmap{\effect}{\anno{\evar}{\embellished}}}$ & coeffect binding \\
         \end{tabular}
       \end{center}
 
@@ -193,7 +196,7 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\hastype{\context}{\term}{\type}$}
+        \framebox{$\hastype{\context}{\term}{\embellished}$}
       \end{center}
 
       \medskip
@@ -205,55 +208,55 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\apply{\context}{\evar} = \type$}
+          \AxiomC{$\apply{\context}{\evar} = \embellished$}
         \RightLabel{(\textsc{T-Variable})}
-        \UnaryInfC{$\hastype{\context}{\evar}{\type}$}
+        \UnaryInfC{$\hastype{\context}{\evar}{\embellished}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\type_1}{\ktembellished}$}
-          \AxiomC{$\hastype{\cextend{\context}{\anno{\evar}{\type_1}}}{\term}{\type_2}$}
+          \AxiomC{$\hastype{\context}{\embellished_1}{\ktembellished}$}
+          \AxiomC{$\hastype{\cextend{\context}{\anno{\evar}{\embellished_1}}}{\term}{\embellished_2}$}
         \RightLabel{(\textsc{T-Abstraction})}
-        \BinaryInfC{$\hastype{\context}{\parens{\eabs{\anno{\evar}{\type_1}}{\term}}}{\tembellished{\parens{\tarrow{\type_1}{\type_2}}}{\tempty}{\tempty}}$}
+        \BinaryInfC{$\hastype{\context}{\parens{\eabs{\anno{\evar}{\embellished_1}}{\term}}}{\tembellished{\parens{\tarrow{\embellished_1}{\embellished_2}}}{\tempty}{\tempty}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\term_1}{\type_1}$}
-          \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\parens{\tarrow{\type_2}{\tembellished{\type_3}{\type_4}{\type_6}}}}{\type_5}{\type_7}}$}
-          \AxiomC{$\subtype{\type_1}{\type_2}$}
+          \AxiomC{$\hastype{\context}{\term_1}{\embellished_1}$}
+          \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\parens{\tarrow{\embellished_2}{\tembellished{\proper}{\row_1}{\row_3}}}}{\row_2}{\row_4}}$}
+          \AxiomC{$\subtype{\embellished_1}{\embellished_2}$}
         \RightLabel{(\textsc{T-Application})}
-        \TrinaryInfC{$\hastype{\context}{\eapp{\term_2}{\term_1}}{\tembellished{\type_3}{\tunion{\type_4}{\type_5}}{\tunion{\type_6}{\type_7}}}$}
+        \TrinaryInfC{$\hastype{\context}{\eapp{\term_2}{\term_1}}{\tembellished{\proper}{\tunion{\row_1}{\row_2}}{\tunion{\row_3}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\cextend{\context}{\anno{\tvar}{\kind}}}{\term}{\type}$}
+          \AxiomC{$\hastype{\cextend{\context}{\anno{\tvar}{\kind}}}{\term}{\embellished}$}
         \RightLabel{(\textsc{T-TypeAbstraction})}
-        \UnaryInfC{$\hastype{\context}{\parens{\etabs{\anno{\tvar}{\kind}}{\term}}}{\tembellished{\parens{\tforall{\anno{\tvar}{\kind}}{\type}}}{\tempty}{\tempty}}$}
+        \UnaryInfC{$\hastype{\context}{\parens{\etabs{\anno{\tvar}{\kind}}{\term}}}{\tembellished{\parens{\tforall{\anno{\tvar}{\kind}}{\embellished}}}{\tempty}{\tempty}}$}
       \end{prooftree}
 
       \begin{prooftree}
-        \AxiomC{$\hastype{\context}{\term}{\tembellished{\parens{\tforall{\anno{\tvar}{\kind}}{\tembellished{\type_1}{\type_3}{\type_5}}}}{\type_4}{\type_6}}$}
-          \AxiomC{$\hastype{\context}{\type_2}{\kind}$}
+        \AxiomC{$\hastype{\context}{\term}{\tembellished{\parens{\tforall{\anno{\tvar}{\kind}}{\tembellished{\proper}{\row_1}{\row_3}}}}{\row_2}{\row_4}}$}
+          \AxiomC{$\hastype{\context}{\type}{\kind}$}
         \RightLabel{(\textsc{T-TypeApplication})}
-        \BinaryInfC{$\hastype{\context}{\etapp{\term}{\type_2}}{\tembellished{\substitute{\type_1}{\tvar}{\type_2}}{\tunion{\substitute{\type_3}{\tvar}{\type_2}}{\type_4}}{\tunion{\substitute{\type_5}{\tvar}{\type_2}}{\type_6}}}$}
+        \BinaryInfC{$\hastype{\context}{\etapp{\term}{\type}}{\tembellished{\substitute{\proper}{\tvar}{\type}}{\tunion{\substitute{\row_1}{\tvar}{\type}}{\row_2}}{\tunion{\substitute{\row_3}{\tvar}{\type}}{\row_4}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\term_1}{\type_1}$}
-          \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\type_2}{\type_3}{\type_4}}$}
-          \AxiomC{$\apply{\effectmap}{\effect} = \anno{\evar}{\type_5}$}
-          \AxiomC{$\subtype{\type_1}{\type_5}$}
+          \AxiomC{$\hastype{\context}{\term_1}{\embellished_1}$}
+          \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\proper}{\row_1}{\row_2}}$}
+          \AxiomC{$\apply{\effectmap}{\effect} = \anno{\evar}{\embellished_2}$}
+          \AxiomC{$\subtype{\embellished_1}{\embellished_2}$}
         \RightLabel{(\textsc{T-Provide})}
-        \QuaternaryInfC{$\hastype{\context}{\eprovide{\effect}{\term_1}{\term_2}}{\tembellished{\type_2}{\tdiff{\type_3}{\tsingleton{\effect}}}{\type_4}}$}
+        \QuaternaryInfC{$\hastype{\context}{\eprovide{\effect}{\term_1}{\term_2}}{\tembellished{\proper}{\tdiff{\row_1}{\tsingleton{\effect}}}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\term_1}{\type_1}$}
-          \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\type_2}{\type_3}{\type_4}}$}
-          \AxiomC{$\apply{\coeffectmap}{\effect} = \anno{\evar}{\type_5}$}
-          \AxiomC{$\subtype{\type_1}{\type_5}$}
+          \AxiomC{$\hastype{\context}{\term_1}{\embellished_1}$}
+          \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\proper}{\row_1}{\row_2}}$}
+          \AxiomC{$\apply{\coeffectmap}{\effect} = \anno{\evar}{\embellished_2}$}
+          \AxiomC{$\subtype{\embellished_1}{\embellished_2}$}
         \RightLabel{(\textsc{T-CoProvide})}
-        \QuaternaryInfC{$\hastype{\context}{\ecoprovide{\effect}{\term_1}{\term_2}}{\tembellished{\type_2}{\type_3}{\tunion{\type_4}{\effect}}}$}
+        \QuaternaryInfC{$\hastype{\context}{\ecoprovide{\effect}{\term_1}{\term_2}}{\tembellished{\proper}{\row_1}{\tunion{\row_2}{\tsingleton{\effect}}}}$}
       \end{prooftree}
 
       \caption{Typing rules}\label{fig:typing_rules}
@@ -282,49 +285,49 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\type_1}{\type_2}$}
-          \AxiomC{$\subtype{\type_3}{\type_4}$}
-          \AxiomC{$\subtype{\type_6}{\type_5}$}
+          \AxiomC{$\subtype{\proper_1}{\proper_2}$}
+          \AxiomC{$\subtype{\row_1}{\row_2}$}
+          \AxiomC{$\subtype{\row_4}{\row_3}$}
         \RightLabel{(\textsc{ST-EmbellishedType})}
-        \TrinaryInfC{$\subtype{\tembellished{\type_1}{\type_3}{\type_5}}{\tembellished{\type_2}{\type_4}{\type_6}}$}
+        \TrinaryInfC{$\subtype{\tembellished{\proper_1}{\row_1}{\row_3}}{\tembellished{\proper_2}{\row_2}{\row_4}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\type_3}{\type_1}$}
-          \AxiomC{$\subtype{\type_2}{\type_4}$}
+          \AxiomC{$\subtype{\embellished_3}{\embellished_1}$}
+          \AxiomC{$\subtype{\embellished_2}{\embellished_4}$}
         \RightLabel{(\textsc{ST-Arrow})}
-        \BinaryInfC{$\subtype{\tarrow{\type_1}{\type_2}}{\tarrow{\type_3}{\type_4}}$}
+        \BinaryInfC{$\subtype{\tarrow{\embellished_1}{\embellished_2}}{\tarrow{\embellished_3}{\embellished_4}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\type_1}{\type_2}$}
+          \AxiomC{$\subtype{\embellished_1}{\embellished_2}$}
         \RightLabel{(\textsc{ST-ForAll})}
-        \UnaryInfC{$\subtype{\tforall{\anno{\tvar}{\kind}}{\type_1}}{\tforall{\anno{\tvar}{\kind}}{\type_2}}$}
+        \UnaryInfC{$\subtype{\tforall{\anno{\tvar}{\kind}}{\embellished_1}}{\tforall{\anno{\tvar}{\kind}}{\embellished_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{ST-Empty})}
-        \UnaryInfC{$\subtype{\tempty}{\type}$}
+        \UnaryInfC{$\subtype{\tempty}{\row}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\type_1}{\type_3}$}
-          \AxiomC{$\subtype{\type_2}{\type_3}$}
+          \AxiomC{$\subtype{\row_1}{\row_3}$}
+          \AxiomC{$\subtype{\row_2}{\row_3}$}
         \RightLabel{(\textsc{ST-Union})}
-        \BinaryInfC{$\subtype{\tunion{\type_1}{\type_2}}{\type_3}$}
+        \BinaryInfC{$\subtype{\tunion{\row_1}{\row_2}}{\row_3}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{ST-WeakeningLeft})}
-        \UnaryInfC{$\subtype{\type_1}{\tunion{\type_1}{\type_2}}$}
+        \UnaryInfC{$\subtype{\row_1}{\tunion{\row_1}{\row_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{}
         \RightLabel{(\textsc{ST-WeakeningRight})}
-        \UnaryInfC{$\subtype{\type_2}{\tunion{\type_1}{\type_2}}$}
+        \UnaryInfC{$\subtype{\row_2}{\tunion{\row_1}{\row_2}}$}
       \end{prooftree}
 
       \caption{Subtyping}\label{fig:subtyping}
@@ -346,11 +349,11 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\type_1}{\kproper}$}
-          \AxiomC{$\hastype{\context}{\type_2}{\krow}$}
-          \AxiomC{$\hastype{\context}{\type_3}{\krow}$}
+          \AxiomC{$\hastype{\context}{\proper_1}{\kproper}$}
+          \AxiomC{$\hastype{\context}{\row_1}{\krow}$}
+          \AxiomC{$\hastype{\context}{\row_2}{\krow}$}
         \RightLabel{(\textsc{K-EmbellishedType})}
-        \TrinaryInfC{$\hastype{\context}{\tembellished{\type_1}{\type_2}{\type_3}}{\ktembellished}$}
+        \TrinaryInfC{$\hastype{\context}{\tembellished{\proper_1}{\row_1}{\row_2}}{\ktembellished}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -360,16 +363,16 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\type_1}{\ktembellished}$}
-          \AxiomC{$\hastype{\context}{\type_2}{\ktembellished}$}
+          \AxiomC{$\hastype{\context}{\embellished_1}{\ktembellished}$}
+          \AxiomC{$\hastype{\context}{\embellished_2}{\ktembellished}$}
         \RightLabel{(\textsc{K-Arrow})}
-        \BinaryInfC{$\hastype{\context}{\tarrow{\type_1}{\type_2}}{\kproper}$}
+        \BinaryInfC{$\hastype{\context}{\tarrow{\embellished_1}{\embellished_2}}{\kproper}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\cextend{\context}{\anno{\tvar}{\kind}}}{\type}{\ktembellished}$}
+          \AxiomC{$\hastype{\cextend{\context}{\anno{\tvar}{\kind}}}{\embellished}{\ktembellished}$}
         \RightLabel{(\textsc{K-ForAll})}
-        \UnaryInfC{$\hastype{\context}{\tforall{\anno{\tvar}{\kind}}{\type}}{\kproper}$}
+        \UnaryInfC{$\hastype{\context}{\tforall{\anno{\tvar}{\kind}}{\embellished}}{\kproper}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -379,16 +382,16 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\apply{\effectmap}{\effect} = \anno{\evar}{\type}$}
+          \AxiomC{$\apply{\effectmap}{\effect} = \anno{\evar}{\embellished}$}
         \RightLabel{(\textsc{K-SingletonRow})}
         \UnaryInfC{$\hastype{\context}{\tsingleton{\effect}}{\krow}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\type_1}{\krow}$}
-          \AxiomC{$\hastype{\context}{\type_2}{\krow}$}
+          \AxiomC{$\hastype{\context}{\row_1}{\krow}$}
+          \AxiomC{$\hastype{\context}{\row_2}{\krow}$}
         \RightLabel{(\textsc{K-UnionRow})}
-        \BinaryInfC{$\hastype{\context}{\tunion{\type_1}{\type_2}}{\krow}$}
+        \BinaryInfC{$\hastype{\context}{\tunion{\row_1}{\row_2}}{\krow}$}
       \end{prooftree}
 
       \caption{Kinding rules}\label{fig:subsumption}
@@ -404,25 +407,25 @@
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\subtype{\tsingleton{\effect}}{\type}$}
-          \AxiomC{$\hastype{\context}{\type}{\krow}$}
+          \AxiomC{$\subtype{\tsingleton{\effect}}{\row}$}
+          \AxiomC{$\hastype{\context}{\row}{\krow}$}
         \RightLabel{(\textsc{WFE-Unit})}
-        \BinaryInfC{$\ewellformed{\context}{\emmap{\effect}{\tembellished{\tunit}{\type}{\tempty}}}$}
+        \BinaryInfC{$\ewellformed{\context}{\emmap{\effect}{\tembellished{\tunit}{\row}{\tempty}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\ewellformed{\context}{\emmap{\effect}{\type_2}}$}
-          \AxiomC{$\hastype{\context}{\type_1}{\ktembellished}$}
-          \AxiomC{$\hastype{\context}{\type_2}{\ktembellished}$}
+          \AxiomC{$\ewellformed{\context}{\emmap{\effect}{\embellished_2}}$}
+          \AxiomC{$\hastype{\context}{\embellished_1}{\ktembellished}$}
+          \AxiomC{$\hastype{\context}{\embellished_2}{\ktembellished}$}
         \RightLabel{(\textsc{WFE-Arrow})}
-        \TrinaryInfC{$\ewellformed{\context}{\emmap{\effect}{\tembellished{\parens{\tarrow{\type_1}{\type_2}}}{\tempty}{\tempty}}}$}
+        \TrinaryInfC{$\ewellformed{\context}{\emmap{\effect}{\tembellished{\parens{\tarrow{\embellished_1}{\embellished_2}}}{\tempty}{\tempty}}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\ewellformed{\cextend{\context}{\anno{\tvar}{\kind}}}{\emmap{\effect}{\type}}$}
-          \AxiomC{$\hastype{\cextend{\context}{\anno{\tvar}{\kind}}}{\type}{\ktembellished}$}
+          \AxiomC{$\ewellformed{\cextend{\context}{\anno{\tvar}{\kind}}}{\emmap{\effect}{\embellished}}$}
+          \AxiomC{$\hastype{\cextend{\context}{\anno{\tvar}{\kind}}}{\embellished}{\ktembellished}$}
         \RightLabel{(\textsc{WFE-ForAll})}
-        \BinaryInfC{$\ewellformed{\context}{\emmap{\effect}{\tembellished{\parens{\tforall{\anno{\tvar}{\kind}}{\type}}}{\tempty}{\tempty}}}$}
+        \BinaryInfC{$\ewellformed{\context}{\emmap{\effect}{\tembellished{\parens{\tforall{\anno{\tvar}{\kind}}{\embellished}}}{\tempty}{\tempty}}}$}
       \end{prooftree}
 
       \caption{Effect well-formedness}\label{fig:effect_well_formedness}
@@ -432,16 +435,16 @@
   \begin{figure}
     \begin{mdframed}[backgroundcolor=none]
       \begin{center}
-        \framebox{$\ecowellformed{\context}{\emmap{\effect}{\type}}$}
+        \framebox{$\ecowellformed{\context}{\emmap{\effect}{\proper}}$}
       \end{center}
 
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\context}{\type_1}{\kproper}$}
-          \AxiomC{$\hastype{\context}{\type_2}{\ktembellished}$}
+          \AxiomC{$\hastype{\context}{\proper}{\kproper}$}
+          \AxiomC{$\hastype{\context}{\embellished}{\ktembellished}$}
         \RightLabel{(\textsc{WFC-Arrow})}
-        \BinaryInfC{$\ecowellformed{\context}{\emmap{\effect}{\tembellished{\parens{\tarrow{\tembellished{\type_1}{\tempty}{\tsingleton{\effect}}}{\type_2}}}{\tempty}{\tempty}}}$}
+        \BinaryInfC{$\ecowellformed{\context}{\emmap{\effect}{\tembellished{\parens{\tarrow{\tembellished{\proper}{\tempty}{\tsingleton{\effect}}}{\embellished}}}{\tempty}{\tempty}}}$}
       \end{prooftree}
 
       \caption{Coeffect well-formedness}\label{fig:coeffect_well_formedness}
@@ -449,19 +452,19 @@
   \end{figure}
 
   \begin{definition}[Effect row membership]
-    Let $\context \vdash \type_1 \in \type_2$ be the smallest relation satisfying:
+    Let $\context \vdash \row_1 \in \row_2$ be the smallest relation satisfying:
     \begin{enumerate}
-      \item if $\hastype{\context}{\tsingleton{\type}}{\krow}$ then $\type \in \tsingleton{\type}$
-      \item if $\context \vdash \type_1 \in \type_2$ and $\hastype{\context}{\type_2}{\krow}$ then $\type_1 \in \tunion{\type_2}{\type_3}$
-      \item if $\context \vdash \type_1 \in \type_3$ and $\hastype{\context}{\type_2}{\krow}$ then $\type_1 \in \tunion{\type_2}{\type_3}$
+      \item if $\hastype{\context}{\tsingleton{\effect}}{\krow}$ then $\effect \in \tsingleton{\effect}$
+      \item if $\context \vdash \effect \in \row_2$ and $\hastype{\context}{\row_2}{\krow}$ then $\effect \in \tunion{\row_2}{\row_3}$
+      \item if $\context \vdash \effect \in \row_3$ and $\hastype{\context}{\row_2}{\krow}$ then $\effect \in \tunion{\row_2}{\row_3}$
     \end{enumerate}
   \end{definition}
 
   \begin{theorem}[Effect row subtyping]
-    For any $\context, \type_1, \type_2$, the following are equivalent:
+    For any $\context, \row_1, \row_2$, the following are equivalent:
     \begin{enumerate}
-      \item if $\hastype{\context}{\type_1}{\krow}$ and $\hastype{\context}{\type_2}{\krow}$ then $\subtype{\type_1}{\type_2}$
-      \item $\forall \type \;.\; \context \vdash \type \in \type_1 \implies \context \vdash \type \in \type_2$
+      \item if $\hastype{\context}{\row_1}{\krow}$ and $\hastype{\context}{\row_2}{\krow}$ then $\subtype{\row_1}{\row_2}$
+      \item $\forall \effect \;.\; \context \vdash \effect \in \row_1 \implies \context \vdash \effect \in \row_2$
     \end{enumerate}
   \end{theorem}
 


### PR DESCRIPTION
Introduce synonyms for `\tau` to enhance readability. This PR closes https://github.com/stepchowfun/delimited-effects/issues/161.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-type-symbols.pdf) is a link to the PDF generated from this PR.
