### PR TITLE
Rearrange the type symbols to reflect the order in the syntax

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -159,7 +159,7 @@
           & $\eprovide{\effect}{\term}{\term}$ & effect definition \\
           & $\ecoprovide{\effect}{\term}{\term}$ & coeffect definition \\
           \\
-          $\type, \proper, \row, \embellished \Coloneqq$ & & types: \\
+          $\type,\embellished, \proper, \row \Coloneqq$ & & types: \\
           & $\tvar$ & type variable \\
           & $\tembellished{\proper}{\row}{\row}$ & embellished type \\
           & $\tunit$ & unit type \\


### PR DESCRIPTION
Rearrange the type symbols to reflect the order in the syntax.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-type-symbol-ordering.pdf) is a link to the PDF generated from this PR.
