### PR TITLE
Add subtyping rules to distribute difference over union

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -343,6 +343,18 @@
         \UnaryInfC{$\subtype{\row_1}{\tdiff{\row_3}{\row_2}}$}
       \end{prooftree}
 
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Distribute1})}
+        \UnaryInfC{$\subtype{\tunion{\parens{\tdiff{\row_1}{\row_3}}}{\parens{\tdiff{\row_2}{\row_3}}}}{\tdiff{\parens{\tunion{\row_1}{\row_2}}}{\row_3}}$}
+      \end{prooftree}
+
+      \begin{prooftree}
+          \AxiomC{}
+        \RightLabel{(\textsc{ST-Distribute2})}
+        \UnaryInfC{$\subtype{\tdiff{\parens{\tunion{\row_1}{\row_2}}}{\row_3}}{\tunion{\parens{\tdiff{\row_1}{\row_3}}}{\parens{\tdiff{\row_2}{\row_3}}}}$}
+      \end{prooftree}
+
       \caption{Subtyping}\label{fig:subtyping}
     \end{mdframed}
   \end{figure}


### PR DESCRIPTION
Happy to rename the rules to something more descriptive.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-distribute-diff-over-union.pdf) is a link to the PDF generated from this PR.
