### PR TITLE
Fix a bug in the syntax for type application

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -155,7 +155,7 @@
               & $\eabs{\anno{\evar}{\tembellished{\proper}{\row}{\row}}}{\term}$ & abstraction \\
               & $\eapp{\term}{\term}$ & application \\
               & $\etabs{\tvar}{\term}$ & type abstraction \\
-              & $\etapp{\term}{\tembellished{\proper}{\row}{\row}}$ & type application \\
+              & $\etapp{\term}{\proper}$ & type application \\
               & $\etabs{\rvar}{\term}$ & row abstraction \\
               & $\etapp{\term}{\row}$ & row application \\
               & $\eprovide{\effect}{\term}{\term}$ & effect definition \\


### PR DESCRIPTION
Type application should expect a proper type for the argument, not an embellished type.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-type-application.pdf) is a link to the PDF generated from this PR.
