### PR TITLE
Rename R-DifferenceUnion to R-DifferenceDomination

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -336,7 +336,7 @@
 
           \begin{prooftree}
               \AxiomC{}
-            \RightLabel{(\textsc{R-DifferenceUnion})}
+            \RightLabel{(\textsc{R-DifferenceDomination})}
             \UnaryInfC{$\requiv{\rdiff{\row_1}{\parens{\runion{\row_1}{\row_2}}}}{\rempty}$}
           \end{prooftree}
 


### PR DESCRIPTION
Rename `R-DifferenceUnion` to `R-DifferenceDomination`.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-domination.pdf) is a link to the PDF generated from this PR.
