### PR TITLE
Do not allow coeffects in quantified types

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -165,8 +165,8 @@
               & $\tvar$ & type variable \\
               & $\tunit$ & unit type \\
               & $\tarrow{\tembellished{\proper}{}{\row}}{\tembellished{\proper}{\row}{}}$ & arrow type \\
-              & $\tforall{\tvar}{\tembellished{\proper}{\row}{\row}}$ & type-quantified type \\
-              & $\tforall{\rvar}{\tembellished{\proper}{\row}{\row}}$ & row-quantified type \\
+              & $\tforall{\tvar}{\tembellished{\proper}{\row}{}}$ & type-quantified type \\
+              & $\tforall{\rvar}{\tembellished{\proper}{\row}{}}$ & row-quantified type \\
               \\
               $\row \Coloneqq$ & & rows: \\
               & $\rvar$ & row variable \\
@@ -227,27 +227,27 @@
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\hastype{\context}{\term}{\tembellished{\proper}{\row_1}{\row_2}}$}
+              \AxiomC{$\hastype{\context}{\term}{\tembellished{\proper}{\row}{\rempty}}$}
             \RightLabel{(\textsc{T-TypeAbstraction})}
-            \UnaryInfC{$\hastype{\context}{\parens{\etabs{\tvar}{\term}}}{\tembellished{\parens{\tforall{\tvar}{\tembellished{\proper}{\row_1}{\row_2}}}}{\rempty}{\rempty}}$}
+            \UnaryInfC{$\hastype{\context}{\parens{\etabs{\tvar}{\term}}}{\tembellished{\parens{\tforall{\tvar}{\tembellished{\proper}{\row}{}}}}{\rempty}{\rempty}}$}
           \end{prooftree}
 
           \begin{prooftree}
-            \AxiomC{$\hastype{\context}{\term}{\tembellished{\parens{\tforall{\tvar}{\tembellished{\proper_2}{\row_1}{\row_2}}}}{\rempty}{\rempty}}$}
+            \AxiomC{$\hastype{\context}{\term}{\tembellished{\parens{\tforall{\tvar}{\tembellished{\proper_2}{\row}{}}}}{\rempty}{\rempty}}$}
             \RightLabel{(\textsc{T-TypeApplication})}
-            \UnaryInfC{$\hastype{\context}{\etapp{\term}{\proper_1}}{\substitute{\tembellished{\proper_2}{\row_1}{\row_2}}{\tvar}{\proper_1}}$}
+            \UnaryInfC{$\hastype{\context}{\etapp{\term}{\proper_1}}{\substitute{\tembellished{\proper_2}{\row}{\rempty}}{\tvar}{\proper_1}}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\hastype{\context}{\term}{\tembellished{\proper}{\row_1}{\row_2}}$}
+              \AxiomC{$\hastype{\context}{\term}{\tembellished{\proper}{\row}{\rempty}}$}
             \RightLabel{(\textsc{T-RowAbstraction})}
-            \UnaryInfC{$\hastype{\context}{\parens{\etabs{\rvar}{\term}}}{\tembellished{\parens{\tforall{\rvar}{\tembellished{\proper}{\row_1}{\row_2}}}}{\rempty}{\rempty}}$}
+            \UnaryInfC{$\hastype{\context}{\parens{\etabs{\rvar}{\term}}}{\tembellished{\parens{\tforall{\rvar}{\tembellished{\proper}{\row}{}}}}{\rempty}{\rempty}}$}
           \end{prooftree}
 
           \begin{prooftree}
-            \AxiomC{$\hastype{\context}{\term}{\tembellished{\parens{\tforall{\rvar}{\tembellished{\proper}{\row_1}{\row_2}}}}{\rempty}{\rempty}}$}
+            \AxiomC{$\hastype{\context}{\term}{\tembellished{\parens{\tforall{\rvar}{\tembellished{\proper}{\row}{}}}}{\rempty}{\rempty}}$}
             \RightLabel{(\textsc{T-RowApplication})}
-            \UnaryInfC{$\hastype{\context}{\etapp{\term}{\row_3}}{\substitute{\tembellished{\proper}{\row_1}{\row_2}}{\rvar}{\row_3}}$}
+            \UnaryInfC{$\hastype{\context}{\etapp{\term}{\row_3}}{\substitute{\tembellished{\proper}{\row_1}{\rempty}}{\rvar}{\row_3}}$}
           \end{prooftree}
 
           \begin{prooftree}


### PR DESCRIPTION
Do not allow coeffects in quantified types. Coeffect rows cannot be merged, and we need to not allow (row-)quantified types to have coeffects in order to ensure that this never happens.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-quantified-types.pdf) is a link to the PDF generated from this PR.
