### PR TITLE
Remove coprovide from the syntax in the formalization

### DIFF
--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -30,7 +30,6 @@ Inductive term : Type :=
 | erabs : rowId -> term -> term
 | erapp : term -> row -> term
 | eprovide : effectId -> term -> term -> term
-| ecoprovide : effectId -> term -> term -> term
 
 (* Proper types *)
 


### PR DESCRIPTION
Remove `coprovide` from the syntax in the formalization. Looks like we missed this.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-remove-coprovide.pdf) is a link to the PDF generated from this PR.
