### PR TITLE
Add a missing case to the Row data type

### DIFF
--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -3,7 +3,8 @@ module Lib (
   rowEquiv
 ) where
 
-data Row a = REmpty
+data Row a = RVar String
+           | REmpty
            | RSingleton a
            | RUnion (Row a) (Row a)
            | RDifference (Row a) (Row a)


### PR DESCRIPTION
Add a missing case to the `Row` data type.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-rvar.pdf) is a link to the PDF generated from this PR.
