### PR TITLE
Implement shrink for all the Arbitrary instances

### DIFF
--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,6 +1,6 @@
 module Lib (Row(..), rowEquiv) where
 
-import Test.QuickCheck (Arbitrary, Gen, arbitrary, choose)
+import Test.QuickCheck (Arbitrary, Gen, arbitrary, choose, shrink)
 
 data Row a b = RVar b
              | REmpty
@@ -28,6 +28,12 @@ instance (Arbitrary a, Arbitrary b) => Arbitrary (Row a b) where
         x <- arbitrary
         y <- arbitrary
         return $ RDifference x y
+  shrink (RVar x) = []
+  shrink REmpty = []
+  shrink (RSingleton x) = []
+  shrink (RUnion x y) = [x, y] ++ [RUnion x' y' | (x', y') <- shrink (x, y)]
+  shrink (RDifference x y) = [x] ++
+    [RDifference x' y' | (x', y') <- shrink (x, y)]
 
 rowEquiv :: (Eq a, Eq b) => Row a b -> Row a b -> Bool
 rowEquiv x y = True

--- a/implementation/test/Spec.hs
+++ b/implementation/test/Spec.hs
@@ -2,7 +2,7 @@ import Data.List (foldl')
 import Lib (Row(..), rowEquiv)
 import Test.Hspec (describe, hspec, it, pending)
 import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
-import Test.QuickCheck (Arbitrary, arbitrary, elements, property)
+import Test.QuickCheck (Arbitrary, arbitrary, elements, property, shrink)
 
 data Effect = EffectA | EffectB | EffectC | EffectD | EffectE
   deriving (Eq, Show)
@@ -35,6 +35,10 @@ instance Arbitrary Context where
     arbitrary <*>
     arbitrary <*>
     arbitrary
+  shrink c = [
+      Context v' w' x' y' z' |
+      (v', w', x', y', z') <- shrink (getV c, getW c, getX c, getY c, getZ c)
+    ]
 
 closed :: Row a b -> Bool
 closed (RVar x) = False


### PR DESCRIPTION
Implement `shrink` for all the `Arbitrary` instances. This will allow QuickCheck to generate smaller counterexamples.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-shrink.pdf) is a link to the PDF generated from this PR.
