### PR TITLE
Add line length checking for Haskell source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,23 @@ paper: main.pdf
 
 lint:
 	./scripts/check-line-lengths.sh \
-	  .travis.yml \
-	  Makefile \
-	  formalization/*.v \
-	  scripts/*
+	  $(shell \
+	    find . \
+	      -type d \( \
+	        -path ./.git -o \
+	        -path ./.github -o \
+	        -path ./.paper-build -o \
+	        -path ./implementation/.stack-work \
+	      \) -prune -o \
+	      \( \
+		-name '*.hs' -o \
+		-name '*.sh' -o \
+		-name '*.v' -o \
+		-name '*.yml' -o \
+		-name 'Dockerfile' -o \
+		-name 'Makefile' \
+	      \) -print \
+	  )
 
 formalization: $(patsubst %.v,%.vo,$(COQ_SOURCES))
 


### PR DESCRIPTION
Add line length checking for Haskell source files (like we have for other types of source files).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-lint.pdf) is a link to the PDF generated from this PR.
