### PR TITLE
Clean up the Arbitrary Context instance

### DIFF
--- a/implementation/test/Spec.hs
+++ b/implementation/test/Spec.hs
@@ -29,13 +29,12 @@ data Context = Context {
   } deriving (Eq, Show)
 
 instance Arbitrary Context where
-  arbitrary = do
-    v <- arbitrary
-    w <- arbitrary
-    x <- arbitrary
-    y <- arbitrary
-    z <- arbitrary
-    return $ Context v w x y z
+  arbitrary = Context <$>
+    arbitrary <*>
+    arbitrary <*>
+    arbitrary <*>
+    arbitrary <*>
+    arbitrary
 
 closed :: Row a b -> Bool
 closed (RVar x) = False


### PR DESCRIPTION
We could use [Generic.Random.Generic](https://hackage.haskell.org/package/generic-random-0.3.0.0/docs/Generic-Random-Generic.html) from the `generic-random` package to clean it up even more, but that might be overkill.