### PR TITLE
Shrink the first 8 elements of the context streams

### DIFF
--- a/implementation/test/Spec.hs
+++ b/implementation/test/Spec.hs
@@ -75,8 +75,15 @@ contains e (RDifference x y) = contains e x && not (contains e y)
 -- prefix of the (infinite) representation of the Stream.
 newtype ContextStream = ContextStream (Stream Context)
 
+streamShrink :: Arbitrary s => Int -> Stream s -> [Stream s]
+streamShrink n s = if n == 0 then [] else do
+  t <- [s] ++ streamShrink (n - 1) (Data.Stream.tail s)
+  h <- shrink (Data.Stream.head s)
+  return (Cons h t)
+
 instance Arbitrary ContextStream where
   arbitrary = ContextStream <$> (Cons <$> arbitrary <*> arbitrary)
+  shrink (ContextStream s) = ContextStream <$> streamShrink 8 s
 
 instance Show ContextStream where
   show (ContextStream s) = take 1024 (show s) ++ "..."


### PR DESCRIPTION
Shrink the first 8 elements of the context streams to make the counterexamples easier to read.

### Before:

Falsifiable (after 3 tests and 6 shrinks):
Context {getV = RSingleton EffectE, getW = RVar VariableX, getX = REmpty, getY = RVar VariableZ, getZ = RVar VariableV} <:> Context {getV = RSingleton EffectE, getW = RVar VariableV, getX = RSingleton EffectB, getY = REmpty, getZ = RDifference (RVar VariableX) (RVar VariableW)} <:> Context {getV = RUnion (RSingleton EffectD) (RDifference (RVar VariableW) (RUnion (RDifference (RUnion (RVar VariableW) (RVar VariableX)) REmpty) (RSingleton EffectD))), getW = REmpty, getX = RDifference (RVar VariableX) (RUnion (RSingleton EffectB) (RSingleton EffectC)), getY = RSingleton EffectE, getZ = REmpty} <:> Context {getV = RDifference (RVar VariableV) (RDifference REmpty (RDifference (RSingleton EffectC) (RVar VariableX))), getW = REmpty, getX = RDifference (RUnion (RDifference (RSingleton EffectC) (RVar VariableX)) (RDifference (RVar VariableZ) REmpty)) (RSingleton EffectC), getY = RVar VariableZ, getZ = RVar VariableZ} <:> Context {getV = RDifference REmpty (RVar VariableZ), getW = RVar VariableW, getX = RSingleton Effe...
RSingleton EffectD
RVar VariableW

### After:

Falsifiable (after 2 tests and 8 shrinks):
Context {getV = REmpty, getW = RSingleton EffectE, getX = RVar VariableX, getY = REmpty, getZ = RSingleton EffectE} <:> Context {getV = REmpty, getW = RSingleton EffectE, getX = RUnion (RVar VariableX) (RSingleton EffectB), getY = REmpty, getZ = RSingleton EffectE} <:> Context {getV = REmpty, getW = RUnion (RSingleton EffectE) (RVar VariableZ), getX = RUnion (RVar VariableX) (RSingleton EffectB), getY = REmpty, getZ = RSingleton EffectE} <:> Context {getV = REmpty, getW = RUnion (RUnion (RSingleton EffectE) (RVar VariableZ)) (RUnion (RVar VariableX) (RSingleton EffectA)), getX = RUnion (RVar VariableX) (RSingleton EffectB), getY = REmpty, getZ = RSingleton EffectE} <:> Context {getV = REmpty, getW = RDifference (RUnion (RUnion (RSingleton EffectE) (RVar VariableZ)) (RUnion (RVar VariableX) (RSingleton EffectA))) REmpty, getX = RUnion (RVar VariableX) (RSingleton EffectB), getY = REmpty, getZ = RSingleton EffectE} <:> Context {getV = REmpty, getW = RUnion (RDifference (RUnion (RUnion (RSingleton EffectE) (RVar...
RVar VariableX
RSingleton EffectA

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-shrink-streams.pdf) is a link to the PDF generated from this PR.