### PR TITLE
Build using a Docker image that has GHC preinstalled

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,34 +1,31 @@
 FROM debian:stretch
+
+# This command will execute the following actions:
+#   - Update package lists.
+#   - Install the packages
+#       Make,
+#       Coq,
+#       cURL,
+#       pip, for installing the AWS CLI below, and
+#       LaTeX.
+#   - Install the AWS CLI.
+#   - Install Stack.
+#   - Install GHC. The resolver specified in this command must match the one in
+#       implementation/stack.yaml to ensure that we install the version of GHC
+#       that the implementation uses.
+#   - Free up some space by removing the package lists, now that the packages are
+#       installed.
+#   - Free up 2G of disk space by deleting documentation for the packages.
 RUN \
-  # Update package lists.
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-
-  # Install various packages.
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    # Make
     build-essential \
-
-    # Coq
     coq \
-
-    # cURL
     curl \
-
-    # For installing the AWS CLI below
     python-pip \
-
-    # LaTeX
     texlive-full && \
-
-  # Install the AWS CLI.
   pip install awscli && \
-
-  # Install Stack.
   curl -sSL https://get.haskellstack.org/ | sh && \
-
-  # Now that the packages are installed, free up some space by removing the
-  # package lists.
+  stack --resolver lts-9.8 setup && \
   rm -rf /var/lib/apt/lists/* && \
-
-  # Free up 2G of disk space.
   rm -rf /usr/share/doc


### PR DESCRIPTION
Update the Dockerfile to install the version of GHC used by the implementation.