### PR TITLE
Cache the .stack-work directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ os: linux
 dist: trusty
 language: generic
 sudo: required
+cache:
+  directories:
+  - implementation/.stack-work
 services: docker
 script: make docker-build &&
   if [ "$TRAVIS_PULL_REQUEST" = 'false' ]; then


### PR DESCRIPTION
This will speed up builds by caching the package dependencies of the implementation.