### PR TITLE
Define row equivalence as equality of normal forms

### DIFF
--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,4 +1,4 @@
-module Lib (Row(..), rowEquiv) where
+module Lib (Row(..), equivalent) where
 
 import Test.QuickCheck (Arbitrary, Gen, arbitrary, choose, oneof, shrink)
 
@@ -25,5 +25,8 @@ instance (Arbitrary a, Arbitrary b) => Arbitrary (Row a b) where
   shrink (RDifference x y) = [x] ++
     [RDifference x' y' | (x', y') <- shrink (x, y)]
 
-rowEquiv :: (Eq a, Eq b) => Row a b -> Row a b -> Bool
-rowEquiv x y = True
+normalize :: (Ord a, Ord b) => Row a b -> Row a b
+normalize = error "Not yet implemented"
+
+equivalent :: (Ord a, Ord b) => Row a b -> Row a b -> Bool
+equivalent x y = normalize x == normalize y

--- a/implementation/test/Spec.hs
+++ b/implementation/test/Spec.hs
@@ -1,12 +1,12 @@
 import Data.List (foldl')
 import Data.Stream (Stream(..), head, tail)
-import Lib (Row(..), rowEquiv)
+import Lib (Row(..), equivalent)
 import Test.Hspec (describe, hspec, it, pending)
 import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
 import Test.QuickCheck (Arbitrary, arbitrary, elements, property, shrink)
 
 data Effect = EffectA | EffectB | EffectC | EffectD | EffectE
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 effects = [EffectA, EffectB, EffectC, EffectD, EffectE]
 
@@ -14,7 +14,7 @@ instance Arbitrary Effect where
   arbitrary = elements effects
 
 data Variable = VariableV | VariableW | VariableX | VariableY | VariableZ
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 variables = [VariableV, VariableW, VariableX, VariableY, VariableZ]
 
@@ -106,10 +106,10 @@ spec cs x y =
     r1 = subUntilClosed cs x
     r2 = subUntilClosed cs y
   in
-    rowEquiv r1 r2 == all (\e -> contains e r1 == contains e r2) effects
+    equivalent r1 r2 == all (\e -> contains e r1 == contains e r2) effects
 
 main :: IO ()
 main = hspec $ modifyMaxSuccess (const 1000000) $ do
-  describe "rowEquiv" $ do
+  describe "equivalent" $ do
     it "returns True iff the rows contain the same set of effects for any \
       \substitution" $ pending -- property spec


### PR DESCRIPTION
Define row equivalence as equality of normal forms.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-normalize.pdf) is a link to the PDF generated from this PR.
