### PR TITLE
Implement effect row equivalence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ docker-deps:
 docker-build:
 	docker run \
 	  --rm \
-	  --ulimit nofile=65536:65536 \
 	  --volume $$(pwd):/root/delimited-effects \
 	  stephanmisc/delimited-effects:deps \
 	  sh -c 'cd /root/delimited-effects && make'

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,32 +1,127 @@
 module Lib (Row(..), equivalent) where
 
+import Data.List (delete, nub, sort)
 import Test.QuickCheck (Arbitrary, arbitrary, oneof, shrink)
 
+-- A row denotes some set of effects. Rows may contain variables which stand
+-- for other rows.
 data Row a b
-  = RVar b
+  = RVariable a
   | REmpty
-  | RSingleton a
+  | RSingleton b
   | RUnion (Row a b) (Row a b)
   | RDifference (Row a b) (Row a b)
   deriving (Eq, Show)
 
+-- This instance allows us to generate random rows for testing purposes.
 instance (Arbitrary a, Arbitrary b) => Arbitrary (Row a b) where
   arbitrary = oneof
-    [ RVar <$> arbitrary
+    [ RVariable <$> arbitrary
     , pure REmpty
     , RSingleton <$> arbitrary
     , RUnion <$> arbitrary <*> arbitrary
     , RDifference <$> arbitrary <*> arbitrary
     ]
-  shrink (RVar _) = []
+  shrink (RVariable _) = []
   shrink REmpty = []
   shrink (RSingleton _) = []
   shrink (RUnion x y) = [x, y] ++ [RUnion x' y' | (x', y') <- shrink (x, y)]
   shrink (RDifference x y) = [x] ++
     [RDifference x' y' | (x', y') <- shrink (x, y)]
 
-normalize :: (Ord a, Ord b) => Row a b -> Row a b
-normalize = error "Not yet implemented"
+-- To determine whether two rows are equivalent, we first convert them into
+-- propositional formulae by embedding them into a Boolean ring. Then
+-- equivalence is just equality of algebraic normal forms.
+data BooleanRing a b
+  = BAVariable a
+  | BASingleton b
+  | BAFalse
+  | BATrue
+  | BAAnd (BooleanRing a b) (BooleanRing a b)
+  | BAXor (BooleanRing a b) (BooleanRing a b)
+  deriving (Eq, Show)
 
+-- In order to find a canonical form for a propositional formula, we need to
+-- sort the elements.  Note that the constants (true/false) are defined to come
+-- first; this allows us to efficiently remove them in the end after sorting.
+instance (Ord a, Ord b) => Ord (BooleanRing a b) where
+  compare BAFalse BAFalse = EQ
+  compare BAFalse _ = LT
+  compare BATrue BAFalse = GT
+  compare BATrue BATrue = EQ
+  compare BATrue _ = LT
+  compare (BAVariable _) BAFalse = GT
+  compare (BAVariable _) BATrue = GT
+  compare (BAVariable x) (BAVariable y) = compare x y
+  compare (BAVariable _) _ = LT
+  compare (BASingleton _) BAFalse = GT
+  compare (BASingleton _) BATrue = GT
+  compare (BASingleton _) (BAVariable _) = GT
+  compare (BASingleton x) (BASingleton y) = compare x y
+  compare (BASingleton _) _ = LT
+  compare (BAAnd _ _) BAFalse = GT
+  compare (BAAnd _ _) BATrue = GT
+  compare (BAAnd _ _) (BAVariable _) = GT
+  compare (BAAnd _ _) (BASingleton _) = GT
+  compare (BAAnd x y) (BAAnd w v) = case compare x w of
+    LT -> LT
+    EQ -> compare y v
+    GT -> GT
+  compare (BAAnd _ _) _ = LT
+  compare (BAXor _ _) BAFalse = GT
+  compare (BAXor _ _) BATrue = GT
+  compare (BAXor _ _) (BAVariable _) = GT
+  compare (BAXor _ _) (BASingleton _) = GT
+  compare (BAXor _ _) (BAAnd _ _) = GT
+  compare (BAXor x y) (BAXor w v) = case compare x w of
+    LT -> LT
+    EQ -> compare y v
+    GT -> GT
+
+-- This function converts a row into a propositional formula.
+embed :: Row a b -> BooleanRing a b
+embed (RVariable x) = BAVariable x
+embed REmpty = BAFalse
+embed (RSingleton x) = BASingleton x
+embed (RUnion x y) =
+  BAXor (embed x) (BAXor (embed y) (BAAnd (embed x) (embed y)))
+embed (RDifference x y) =
+  BAXor (embed x) (BAAnd (embed x) (embed y))
+
+-- This function removes identical pairs of elements from a list. Note that
+-- this is different from deduplication. The input is assumed to be sorted.
+elimPairs :: Eq a => [a] -> [a]
+elimPairs (x : y : xs) =
+  if x == y then elimPairs xs else x : elimPairs (y : xs)
+elimPairs (x : xs) = x : elimPairs xs
+elimPairs [] = []
+
+-- This function counts the number of singletons in a list.
+countSingletons :: [BooleanRing a b] -> Integer
+countSingletons ((BASingleton _) : xs) = 1 + countSingletons xs
+countSingletons (_ : xs) = countSingletons xs
+countSingletons [] = 0
+
+-- This function converts a propositional formula into algebraic normal form,
+-- suitable for comparison.
+normalize :: (Ord a, Ord b) => BooleanRing a b -> [[BooleanRing a b]]
+normalize (BAVariable x) = [[BAVariable x]]
+normalize (BASingleton x) = [[BASingleton x]]
+normalize BAFalse = []
+normalize BATrue = [[BATrue]]
+normalize (BAAnd x y) = do
+  p <- normalize x
+  q <- normalize y
+  let conjunction = nub (sort (p ++ q))
+  if countSingletons conjunction > 1
+  then return [BAFalse]
+  else return $ case conjunction of
+    (BAFalse : _) -> [BAFalse]
+    (BATrue : xs) -> xs
+    xs -> xs
+normalize (BAXor x y) =
+  delete [BAFalse] (elimPairs (sort ((normalize x) ++ (normalize y))))
+
+-- Finally, this is the actual decision procedure for row equivalence.
 equivalent :: (Ord a, Ord b) => Row a b -> Row a b -> Bool
-equivalent x y = normalize x == normalize y
+equivalent x y = normalize (embed x) == normalize (embed y)

--- a/implementation/test/Spec.hs
+++ b/implementation/test/Spec.hs
@@ -3,113 +3,131 @@ import Data.Stream (Stream(..), head, tail)
 import Lib (Row(..), equivalent)
 import Test.Hspec (describe, hspec, it, pending)
 import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
-import Test.QuickCheck (Arbitrary, arbitrary, elements, property, shrink)
+import Test.QuickCheck (
+    Arbitrary,
+    arbitrary,
+    elements,
+    property,
+    shrink,
+    suchThat
+  )
 
 data Effect = EffectA | EffectB | EffectC | EffectD | EffectE
   deriving (Eq, Ord, Show)
 
-effects = [EffectA, EffectB, EffectC, EffectD, EffectE]
-
 instance Arbitrary Effect where
   arbitrary = elements effects
+
+effects = [EffectA, EffectB, EffectC, EffectD, EffectE]
 
 data Variable = VariableV | VariableW | VariableX | VariableY | VariableZ
   deriving (Eq, Ord, Show)
 
-variables = [VariableV, VariableW, VariableX, VariableY, VariableZ]
-
 instance Arbitrary Variable where
   arbitrary = elements variables
 
+variables = [VariableV, VariableW, VariableX, VariableY, VariableZ]
+
 data Context = Context
-  { getV :: Row Effect Variable
-  , getW :: Row Effect Variable
-  , getX :: Row Effect Variable
-  , getY :: Row Effect Variable
-  , getZ :: Row Effect Variable
+  { getV :: Row Variable Effect
+  , getW :: Row Variable Effect
+  , getX :: Row Variable Effect
+  , getY :: Row Variable Effect
+  , getZ :: Row Variable Effect
   } deriving (Eq, Show)
 
-instance Arbitrary Context where
-  arbitrary = Context <$>
-    arbitrary <*>
-    arbitrary <*>
-    arbitrary <*>
-    arbitrary <*>
-    arbitrary
-  shrink c = [
-      Context v' w' x' y' z' |
+-- This type represents a context whose rows are closed.
+newtype ClosedContext = ClosedContext Context
+  deriving Show
+
+instance Arbitrary ClosedContext where
+  arbitrary = ClosedContext <$> (
+      Context <$>
+        (suchThat arbitrary closed) <*>
+        (suchThat arbitrary closed) <*>
+        (suchThat arbitrary closed) <*>
+        (suchThat arbitrary closed) <*>
+        (suchThat arbitrary closed)
+    )
+  shrink (ClosedContext c) = [
+      ClosedContext (Context v' w' x' y' z') |
       (v', w', x', y', z') <- shrink (getV c, getW c, getX c, getY c, getZ c)
     ]
 
 closed :: Row a b -> Bool
-closed (RVar x) = False
+closed (RVariable x) = False
 closed REmpty = True
 closed (RSingleton x) = True
 closed (RUnion x y) = closed x && closed y
 closed (RDifference x y) = closed x && closed y
 
-substitute :: Row Effect Variable -> Context -> Row Effect Variable
-substitute (RVar x) c = case x of
+substitute :: Context -> Row Variable Effect -> Row Variable Effect
+substitute c (RVariable x) = case x of
   VariableV -> getV c
   VariableW -> getW c
   VariableX -> getX c
   VariableY -> getY c
   VariableZ -> getZ c
-substitute REmpty c = REmpty
-substitute (RSingleton x) c = RSingleton x
-substitute (RUnion x y) c = RUnion (substitute x c) (substitute y c)
-substitute (RDifference x y) c = RDifference (substitute x c) (substitute y c)
+substitute c REmpty = REmpty
+substitute c (RSingleton x) = RSingleton x
+substitute c (RUnion x y) = RUnion (substitute c x) (substitute c y)
+substitute c (RDifference x y) = RDifference (substitute c x) (substitute c y)
 
 -- The row is assumed to be closed.
-contains :: Effect -> Row Effect Variable -> Bool
-contains e (RVar x) = error "The row is not closed."
+contains :: Effect -> Row Variable Effect -> Bool
+contains e (RVariable x) = error "The row is not closed."
 contains e REmpty = False
 contains e (RSingleton x) = x == e
 contains e (RUnion x y) = contains e x || contains e y
 contains e (RDifference x y) = contains e x && not (contains e y)
 
--- QuickCheck has a bug where it tries to print the arguments for a failed
--- test case, even if they are infinite (which causes the program to hang).
--- We use infinite Streams, so we need a newtype wrapper to work around this
--- QuickCheck bug. We define a special Show instance which returns only a
--- prefix of the (infinite) representation of the Stream.
-newtype ContextStream = ContextStream (Stream Context)
+occurs :: Effect -> Row Variable Effect -> Bool
+occurs e (RVariable x) = False
+occurs e REmpty = False
+occurs e (RSingleton x) = x == e
+occurs e (RUnion x y) = occurs e x || occurs e y
+occurs e (RDifference x y) = occurs e x || occurs e y
 
-streamShrink :: Arbitrary s => Int -> Stream s -> [Stream s]
-streamShrink n s = if n == 0 then [] else do
-  t <- [s] ++ streamShrink (n - 1) (Data.Stream.tail s)
-  h <- shrink (Data.Stream.head s)
-  return (Cons h t)
+allOccur :: Row Variable Effect -> Bool
+allOccur x = all (\e -> occurs e x) effects
 
-instance Arbitrary ContextStream where
-  arbitrary = ContextStream <$> (Cons <$> arbitrary <*> arbitrary)
-  shrink (ContextStream s) = ContextStream <$> streamShrink 8 s
-
-instance Show ContextStream where
-  show (ContextStream s) = take 1024 (show s) ++ "..."
-
-csHead :: ContextStream -> Context
-csHead (ContextStream s) = Data.Stream.head s
-
-csTail :: ContextStream -> ContextStream
-csTail (ContextStream s) = ContextStream (Data.Stream.tail s)
-
-subUntilClosed :: ContextStream -> Row Effect Variable -> Row Effect Variable
-subUntilClosed cs x = fst $ until
-  (closed . fst)
-  (\(r, s) -> (substitute r (csHead s), csTail s))
-  (x, cs)
-
-spec :: ContextStream -> Row Effect Variable -> Row Effect Variable -> Bool
-spec cs x y =
+specForward :: ClosedContext ->
+               Row Variable Effect ->
+               Row Variable Effect ->
+               Bool
+specForward (ClosedContext c) x y =
   let
-    r1 = subUntilClosed cs x
-    r2 = subUntilClosed cs y
+    r1 = substitute c x
+    r2 = substitute c y
   in
-    equivalent r1 r2 == all (\e -> contains e r1 == contains e r2) effects
+    all (\e -> contains e r1 == contains e r2) effects ||
+      not (equivalent x y)
+
+specReverse :: Row Variable Effect -> Row Variable Effect -> Bool
+specReverse p q = allOccur p || allOccur q || not (all id (
+    do
+      v <- effects
+      w <- effects
+      x <- effects
+      y <- effects
+      z <- effects
+      let v' = RSingleton v
+      let w' = RSingleton w
+      let x' = RSingleton x
+      let y' = RSingleton y
+      let z' = RSingleton z
+      let c = Context v' w' x' y' z'
+      let r1 = substitute c p
+      let r2 = substitute c q
+      return (all (\e -> contains e r1 == contains e r2) effects)
+  )) || equivalent p q
 
 main :: IO ()
-main = hspec $ modifyMaxSuccess (const 1000000) $ do
+main = hspec $ do
   describe "equivalent" $ do
-    it "returns True iff the rows contain the same set of effects for any \
-      \substitution" $ pending -- property spec
+    modifyMaxSuccess (const 1000) $
+      it "returns False for any two rows if they contain different effects \
+        \after some closed substitution" $ property specForward
+    modifyMaxSuccess (const 100000) $
+      it "returns True for any two rows if they contain the same effects \
+        \after all possible singleton substitutions" $ property specReverse


### PR DESCRIPTION
Implement effect row equivalence decision procedure, based on:

- A great idea by @ewang12 to embed the effect rows into propositional logic (equivalent to adding a complement operation) and check for equivalence in that language
- An experiment by me to use a Boolean ring for the propositional logic language and convert the formulas into algebraic normal form for easy comparison

I noticed that our test was wrong (it would fail sometimes when it should have passed), so I replaced the broken spec with two new ones.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-normalize.pdf) is a link to the PDF generated from this PR.
