### PR TITLE
Turn on pedantic mode for Haskell and fix all the errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ formalization: $(patsubst %.v,%.vo,$(COQ_SOURCES))
 
 implementation:
 	cd implementation && \
-	  stack build --install-ghc --allow-different-user && \
+	  stack build --pedantic --install-ghc --allow-different-user && \
 	  stack test --allow-different-user
 
 clean: clean-paper clean-formalization clean-implementation

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,6 +1,6 @@
 module Lib (Row(..), equivalent) where
 
-import Test.QuickCheck (Arbitrary, Gen, arbitrary, choose, oneof, shrink)
+import Test.QuickCheck (Arbitrary, arbitrary, oneof, shrink)
 
 data Row a b
   = RVar b
@@ -18,9 +18,9 @@ instance (Arbitrary a, Arbitrary b) => Arbitrary (Row a b) where
     , RUnion <$> arbitrary <*> arbitrary
     , RDifference <$> arbitrary <*> arbitrary
     ]
-  shrink (RVar x) = []
+  shrink (RVar _) = []
   shrink REmpty = []
-  shrink (RSingleton x) = []
+  shrink (RSingleton _) = []
   shrink (RUnion x y) = [x, y] ++ [RUnion x' y' | (x', y') <- shrink (x, y)]
   shrink (RDifference x y) = [x] ++
     [RDifference x' y' | (x', y') <- shrink (x, y)]


### PR DESCRIPTION
Turn on pedantic mode for Haskell and fix all the errors.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-pedantic.pdf) is a link to the PDF generated from this PR.
