### PR TITLE
Use e[e/x] notation for substitution as recommended by Guy Steele

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -55,7 +55,7 @@
 \newcommand\anno[2]{#1 : #2}
 \newcommand\apply[2]{#1\parens{#2}}
 \newcommand\parens[1]{\left( #1 \right)}
-\newcommand\substitute[3]{#1 \left[ #2 \mapsto #3 \right]}
+\newcommand\substitute[3]{#1 \left[ #3 / #2 \right]}
 
 % Terms
 \newcommand\term{t}


### PR DESCRIPTION
I recently watched [this talk](https://www.youtube.com/watch?v=dCuZkaaou0Q) by Guy Steele, which discusses notation in CS papers. Apparently Guy found dozens of different notations in use for substitution, and we are using one of the more ambiguous ones (because `\mapsto` is also used for map update). So this PR switches it to use the more popular `e[e/x]` notation.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-notation.pdf) is a link to the PDF generated from this PR.
