### PR TITLE
Reintroduce using

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -65,7 +65,7 @@
 \newcommand\eapp[2]{#1 \; #2}
 \newcommand\etabs[2]{\lambda #1 \; . \; #2}
 \newcommand\etapp[2]{#1 \; #2}
-\newcommand\eprovide[3]{\textbf{provide} \; #1 \; \textbf{with} \; #2 \; \textbf{in} \; #3}
+\newcommand\eprovide[4]{\textbf{provide} \; #1 / #2 \; \textbf{with} \; #3 \; \textbf{in} \; #4}
 
 % Types
 \newcommand\tembellished[2]{{#1}^{\textcolor{violet}{#2}}}
@@ -155,7 +155,7 @@
               & $\etapp{\term}{\type}$ & type application \\
               & $\etabs{\rvar}{\term}$ & row abstraction \\
               & $\etapp{\term}{\row}$ & row application \\
-              & $\eprovide{\effect}{\term}{\term}$ & effect definition \\
+              & $\eprovide{\effect}{\overline{\effect_i}}{\term}{\term}$ & effect definition \\
               \\
               $\type \Coloneqq$ & & types: \\
               & $\tvar$ & type variable \\
@@ -243,11 +243,11 @@
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\apply{\effectmap}{\effect} = \anno{\evar}{\tembellished{\type_1}{\runion{\row_1}{\row_3}}}$}
               \AxiomC{$\hastype{\context}{\term_1}{\tembellished{\type_1}{\row_1}}$}
               \AxiomC{$\hastype{\context}{\term_2}{\tembellished{\type_2}{\row_2}}$}
+              \AxiomC{$\apply{\effectmap}{\effect} = \anno{\evar}{\tembellished{\substitute{\type_1}{\effect_i}{\effect}}{\runion{\substitute{\row_1}{\effect_i}{\effect}}{\row_3}}}$}
             \RightLabel{(\textsc{T-Provide})}
-            \TrinaryInfC{$\hastype{\context}{\eprovide{\effect}{\term_1}{\term_2}}{\tembellished{\type_2}{\rdiff{\row_2}{\rsingleton{\effect}}}}$}
+            \TrinaryInfC{$\hastype{\context}{\eprovide{\effect}{\overline{\effect_i}}{\term_1}{\term_2}}{\tembellished{\type_2}{\runion{\parens{\rdiff{\row_2}{\rsingleton{\effect}}}}{\effect_i}}}$}
           \end{prooftree}
 
           \caption{Typing rules}\label{fig:typing_rules}


### PR DESCRIPTION
Reintroduce `using` (with an experimental new syntax).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-using.pdf) is a link to the PDF generated from this PR.