### PR TITLE
Write subtyping section

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -78,6 +78,16 @@
 \newcommand\rUnion[2]{#1 \cup #2}
 \newcommand\rDiff[2]{#1 \setminus #2}
 
+% Boolean rings
+\newcommand\brLang{\mathcal{R}}
+\newcommand\brEmbed[1]{\mathcal{N}\parens{#1}}
+\newcommand\brTerm{e}
+\newcommand\brVar{x}
+\newcommand\brZero{0}
+\newcommand\brOne{1}
+\newcommand\brAdd[2]{#1 \; \oplus \; #2}
+\newcommand\brMul[2]{#1 \; \cdot \; #2}
+
 % Type contexts
 \newcommand\context{\Gamma}
 \newcommand\cEmpty{\varnothing_{\context}}
@@ -89,14 +99,6 @@
 \newcommand\emMap[2]{#1 \mapsto #2}
 \newcommand\emEmpty{\varnothing_{\effectMap}}
 \newcommand\emExtend[2]{#1, #2}
-
-% Boolean rings
-\newcommand\brSym{\mathcal{R}}
-\newcommand\brEmbed[1]{\mathcal{R}(#1)}
-\newcommand\brUniq[1]{\mathcal{S}(#1)}
-\newcommand\brPlus[2]{#1 \oplus #2}
-\newcommand\brTimes[2]{#1 #2}
-\newcommand\brVar{e}
 
 % Judgments
 \newcommand\subrowSym{\sqsubseteq}
@@ -176,24 +178,24 @@
 
       An effect row $\row$ models a set of effects $\effect$ constructed by a finite number of unions and relative complements. We define a relation $\subrowSym$ for modeling set inclusion on effect rows.
 
-      For any two rows $\row_1$, $\row_2$, $\row_1 \subrowSym \row_2$ if and only if $\brEmbed{\rDiff{\row_1}{\row_2}}\brUniq{\rDiff{\row_1}{\row_2}} = \brEmbed{\rEmpty}$. $\brEmbed{\row}$ is defined as follows:
+      The algorithm defining $\subrowSym$ takes two effect rows $\row_1$ and $\row_2$, and constructs a normal form for the effect row $\rDiff{\row_2}{\row_1}$. Normal forms may be compared for equality, and are built in the following language:
+
+      \begin{center}
+        $\brTerm \Coloneqq \brZero \mathrel{|} \brOne \mathrel{|} \brVar \mathrel{|} \brMul{\brTerm}{\brTerm} \mathrel{|} \brAdd{\brTerm}{\brTerm}$
+      \end{center}
+
+      The function $\brEmbed{\row}$ describes the translation of $\row$ to this language.
 
       \begin{enumerate}
-      \item $\brEmbed{\rEmpty} = 0$
-      \item $\brEmbed{\rSingleton{\effect_i}} = \brVar_i$
-      \item $\brEmbed{\rUnion{\row_1}{\row_2}} = \brPlus{\brPlus{\brEmbed{\row_1}}{\brEmbed{\row_2}}}{\brTimes{\brEmbed{\row_1}}{\brEmbed{\row_2}}}$
-      \item $\brEmbed{\rDiff{\row_1}{\row_2}} = \brPlus{\brEmbed{\row_1}}{\brTimes{\brEmbed{\row_1}}{\brEmbed{\row_2}}}$
+        \item $\brEmbed{\rEmpty} = 0$
+        \item $\brEmbed{\rSingleton{\effect_i}} = \brVar_i$
+        \item $\brEmbed{\rUnion{\row_1}{\row_2}} = \brAdd{\brAdd{\brEmbed{\row_1}}{\brEmbed{\row_2}}}{\parens{\brMul{\brEmbed{\row_1}}{\brEmbed{\row_2}}}}$
+        \item $\brEmbed{\rDiff{\row_1}{\row_2}} = \brAdd{\brEmbed{\row_1}}{\parens{\brMul{\brEmbed{\row_1}}{\brEmbed{\row_2}}}}$
       \end{enumerate}
 
-      $\row$ is modeled as a series of operations in a boolean ring, where singleton effect rows are uniquely mapped to boolean variables.
+      Given $\row_1$ and $\row_2$, the algorithm returns true when $\brEmbed{\rDiff{\row_2}{\row_1}} = \brEmbed{\rEmpty}$.
 
-      $\brUniq{\row}$ is a boolean term which evaluates to 1 if and only if for all boolean variables derived from distinct singletons in $\row$, at most one variable is 1. Let $\brVar_1 \ldots \brVar_n$ be the boolean variables which occur in $\brEmbed{\row}$.
-
-      $$\brUniq{\row} = $$
-
-      The boolean equation defining $\subrowSym$ can be solved in exponential time.
-
-        \subsubsection{Logical equivalence to set inclusion}
+      The intuition of the algorithm is to build a boolean term which corresponds to a propositional formula describing set inclusion on the effect row.
 
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -90,6 +90,14 @@
 \newcommand\emEmpty{\varnothing_{\effectMap}}
 \newcommand\emExtend[2]{#1, #2}
 
+% Boolean rings
+\newcommand\brSym{\mathcal{R}}
+\newcommand\brEmbed[1]{\mathcal{R}(#1)}
+\newcommand\brUniq[1]{\mathcal{S}(#1)}
+\newcommand\brPlus[2]{#1 \oplus #2}
+\newcommand\brTimes[2]{#1 #2}
+\newcommand\brVar{e}
+
 % Judgments
 \newcommand\subrowSym{\sqsubseteq}
 \newcommand\subtypeSym{\leq}
@@ -167,6 +175,25 @@
     \subsection{Subtyping}
 
       An effect row $\row$ models a set of effects $\effect$ constructed by a finite number of unions and relative complements. We define a relation $\subrowSym$ for modeling set inclusion on effect rows.
+
+      For any two rows $\row_1$, $\row_2$, $\row_1 \subrowSym \row_2$ if and only if $\brEmbed{\rDiff{\row_1}{\row_2}}\brUniq{\rDiff{\row_1}{\row_2}} = \brEmbed{\rEmpty}$. $\brEmbed{\row}$ is defined as follows:
+
+      \begin{enumerate}
+      \item $\brEmbed{\rEmpty} = 0$
+      \item $\brEmbed{\rSingleton{\effect_i}} = \brVar_i$
+      \item $\brEmbed{\rUnion{\row_1}{\row_2}} = \brPlus{\brPlus{\brEmbed{\row_1}}{\brEmbed{\row_2}}}{\brTimes{\brEmbed{\row_1}}{\brEmbed{\row_2}}}$
+      \item $\brEmbed{\rDiff{\row_1}{\row_2}} = \brPlus{\brEmbed{\row_1}}{\brTimes{\brEmbed{\row_1}}{\brEmbed{\row_2}}}$
+      \end{enumerate}
+
+      $\row$ is modeled as a series of operations in a boolean ring, where singleton effect rows are uniquely mapped to boolean variables.
+
+      $\brUniq{\row}$ is a boolean term which evaluates to 1 if and only if for all boolean variables derived from distinct singletons in $\row$, at most one variable is 1. Let $\brVar_1 \ldots \brVar_n$ be the boolean variables which occur in $\brEmbed{\row}$.
+
+      $$\brUniq{\row} = $$
+
+      The boolean equation defining $\subrowSym$ can be solved in exponential time.
+
+        \subsubsection{Logical equivalence to set inclusion}
 
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]


### PR DESCRIPTION
In the subtyping section, we define the subrow relation as a boolean equation, and prove its logical equivalence to set inclusion.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subrow-writeup.pdf) is a link to the PDF generated from this PR.
