### PR TITLE
Add data types for syntax to the Haskell implementation

### DIFF
--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -16,7 +16,8 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Lib
-  other-modules:       Row
+  other-modules:       Subrow
+                     , Syntax
   build-depends:       base >= 4.7 && < 5
                      , containers
                      , QuickCheck
@@ -34,7 +35,8 @@ test-suite implementation-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             LibSpec.hs
-  other-modules:       RowSpec
+  other-modules:       SubrowSpec
+                     , SyntaxSpec
   build-depends:       base
                      , implementation
                      , hspec

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,3 +1,4 @@
 module Lib (Row(..), subrow) where
 
-import Row (Row(..), subrow)
+import Subrow (subrow)
+import Syntax (Row(..))

--- a/implementation/src/Subrow.hs
+++ b/implementation/src/Subrow.hs
@@ -1,14 +1,8 @@
-module Row (Row(..), subrow) where
+module Subrow (subrow) where
 
 import Data.Set (Set)
+import Syntax (Row(..))
 import qualified Data.Set as Set
-
-data Row a
-  = REmpty
-  | RSingleton a
-  | RUnion (Row a) (Row a)
-  | RDifference (Row a) (Row a)
-  deriving (Eq, Show)
 
 data BooleanRing a
   = BRExclusiveAtom a -- At most one exclusive atom may be true

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -1,0 +1,32 @@
+module Syntax
+  ( Term(..)
+  , Type(..)
+  , Row(..)
+  , Context(..)
+  , EffectMap(..) ) where
+
+data Term a
+  = EUnit
+  | EVar a
+  | EAbs a (Type a) (Term a)
+  | EApp (Term a) (Term a)
+  | EProvide a [a] (Term a) (Term a)
+
+data Type a
+  = TUnit
+  | TArrow (Type a) (Type a) (Row a)
+
+data Row a
+  = REmpty
+  | RSingleton a
+  | RUnion (Row a) (Row a)
+  | RDifference (Row a) (Row a)
+  deriving (Eq, Show)
+
+data Context a
+  = CEmpty
+  | CExtend (Context a) a (Type a) (Row a)
+
+data EffectMap a
+  = EMEmpty
+  | EMExtend (EffectMap a) a a (Type a) (Row a)

--- a/implementation/test/LibSpec.hs
+++ b/implementation/test/LibSpec.hs
@@ -1,5 +1,8 @@
-import RowSpec (rowSpec)
+import SubrowSpec (subrowSpec)
+import SyntaxSpec (syntaxSpec)
 import Test.Hspec (hspec)
 
 main :: IO ()
-main = hspec rowSpec
+main = hspec $ do
+  subrowSpec
+  syntaxSpec

--- a/implementation/test/SubrowSpec.hs
+++ b/implementation/test/SubrowSpec.hs
@@ -1,4 +1,4 @@
-module RowSpec (rowSpec) where
+module SubrowSpec (subrowSpec) where
 
 import Data.List (foldl')
 import Data.Stream (Stream(..), head, tail)
@@ -12,8 +12,7 @@ import Test.QuickCheck
   , oneof
   , property
   , shrink
-  , suchThat
-  )
+  , suchThat )
 
 -- Types
 
@@ -75,8 +74,8 @@ specSubrowImpliesContained x y =
   not (subrow x y) ||
   contained x y
 
-rowSpec :: Spec
-rowSpec = describe "subrow" $ modifyMaxSuccess (const 100000) $ do
+subrowSpec :: Spec
+subrowSpec = describe "subrow" $ modifyMaxSuccess (const 100000) $ do
   it "returns True for x <= y if x contains all the effects in y" $
     property specContainedImpliesSubrow
   it "returns True for x <= y implies x contains all the effects in y" $

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -1,0 +1,7 @@
+module SyntaxSpec (syntaxSpec) where
+
+import Test.Hspec (Spec, describe, it, pending)
+
+syntaxSpec :: Spec
+syntaxSpec = describe "syntax" $
+  it "should be correct" $ pending


### PR DESCRIPTION
Add data types for syntax to the Haskell implementation.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-implementation-syntax.pdf) is a link to the PDF generated from this PR.
