### PR TITLE
Add specs for contextLookup and effectMapLookup

### DIFF
--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -37,6 +37,7 @@ test-suite implementation-test
   main-is:             LibSpec.hs
   other-modules:       SubrowSpec
                      , SyntaxSpec
+                     , Types
   build-depends:       base
                      , implementation
                      , hspec

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,4 +1,19 @@
-module Lib (Row(..), subrow) where
+module Lib (
+    Term(..)
+  , Context(..)
+  , EffectMap(..)
+  , Row(..)
+  , Type(..)
+  , contextLookup
+  , effectMapLookup
+  , subrow ) where
 
 import Subrow (subrow)
-import Syntax (Row(..))
+import Syntax (
+    Term(..)
+  , Context(..)
+  , EffectMap(..)
+  , Row(..)
+  , Type(..)
+  , contextLookup
+  , effectMapLookup )

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -24,10 +24,12 @@ data Term a b -- Metavariable: e
   | EAbs a (Type b) (Term a b)
   | EApp (Term a b) (Term a b)
   | EProvide b [b] (Term a b) (Term a b)
+  deriving (Eq, Show)
 
 data Type a -- Metavariable: t
   = TUnit
   | TArrow (Type a) (Type a) (Maybe (Row a))
+  deriving (Eq, Show)
 
 data Row a -- Metavariable: r
   = REmpty
@@ -39,10 +41,12 @@ data Row a -- Metavariable: r
 data Context a b -- Metavariable: c
   = CEmpty
   | CExtend (Context a b) a (Type b) (Row b)
+  deriving (Eq, Show)
 
 data EffectMap a b -- Metavariable: em
   = EMEmpty
   | EMExtend (EffectMap a b) b a (Type b) (Row b)
+  deriving (Eq, Show)
 
 -- Arbitrary instances
 
@@ -64,7 +68,7 @@ instance (Arbitrary a, Arbitrary b) => Arbitrary (Term a b) where
 instance Arbitrary a => Arbitrary (Type a) where
   arbitrary = oneof
     [ pure TUnit
-    , TArrow <$> arbitrary <*> arbitrary <*> arbitrary ]
+    , TArrow <$> arbitrary <*> arbitrary <*> (Just <$> arbitrary) ]
   shrink TUnit = []
   shrink (TArrow t1 t2 r) =
     [TArrow t1' t2' r' | (t1', t2', r') <- shrink (t1, t2, r)]

--- a/implementation/test/SubrowSpec.hs
+++ b/implementation/test/SubrowSpec.hs
@@ -3,22 +3,8 @@ module SubrowSpec (subrowSpec) where
 import Lib (Row(..), subrow)
 import Test.Hspec (Spec, describe, it)
 import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
-import Test.QuickCheck
-  ( Arbitrary
-  , arbitrary
-  , elements
-  , property )
-
--- Types
-
-data Effect = EffectA | EffectB | EffectC | EffectD | EffectE
-  deriving (Eq, Ord, Show)
-
-instance Arbitrary Effect where
-  arbitrary = elements effects
-
-effects :: [Effect]
-effects = [EffectA, EffectB, EffectC, EffectD, EffectE]
+import Test.QuickCheck (property)
+import Types (Effect(..), effects)
 
 -- Helper functions
 
@@ -55,7 +41,7 @@ specSubrowImpliesContained r1 r2 =
   contained r1 r2
 
 subrowSpec :: Spec
-subrowSpec = describe "subrow" $ modifyMaxSuccess (const 100000) $ do
+subrowSpec = modifyMaxSuccess (const 100000) $ describe "subrow" $ do
   it "returns True for r1 <= r2 if r2 contains all the effects in r1" $
     property specContainedImpliesSubrow
   it "returns True for r1 <= r2 implies r2 contains all the effects in r1" $

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -1,9 +1,64 @@
 module SyntaxSpec (syntaxSpec) where
 
-import Test.Hspec (Spec, describe, it, pending)
+import Lib
+  ( Context(..)
+  , EffectMap(..)
+  , Row(..)
+  , Type(..)
+  , contextLookup
+  , effectMapLookup )
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
+import Test.QuickCheck (property)
+import Types (Effect(..), Variable(..))
 
 -- The QuickCheck specs
 
+specContextLookupAfterExtend :: Context Variable Effect
+                                -> Variable
+                                -> Type Effect
+                                -> Row Effect
+                                -> Bool
+specContextLookupAfterExtend c x t r =
+  contextLookup (CExtend c x t r) x == Just (t, r)
+
+specContextExtendAfterLookup :: Context Variable Effect
+                                -> Variable
+                                -> Variable
+                                -> Bool
+specContextExtendAfterLookup c x1 x2 =
+  case contextLookup c x1 of
+    Just (t, r) -> contextLookup (CExtend c x1 t r) x2 == contextLookup c x2
+    Nothing -> True
+
+specEffectMapLookupAfterExtend :: EffectMap Variable Effect
+                                  -> Effect
+                                  -> Variable
+                                  -> Type Effect
+                                  -> Row Effect
+                                  -> Bool
+specEffectMapLookupAfterExtend em z x t r =
+  effectMapLookup (EMExtend em z x t r) z == Just (x, t, r)
+
+specEffectMapExtendAfterLookup :: EffectMap Variable Effect
+                                  -> Effect
+                                  -> Effect
+                                  -> Bool
+specEffectMapExtendAfterLookup em z1 z2 =
+  case effectMapLookup em z1 of
+    Just (x, t, r) ->
+      effectMapLookup (EMExtend em z1 x t r) z2 == effectMapLookup em z2
+    Nothing -> True
+
 syntaxSpec :: Spec
-syntaxSpec = describe "syntax" $
-  it "should be correct" $ pending
+syntaxSpec = modifyMaxSuccess (const 10) $ do
+  describe "contextLookup" $ do
+    it "contextLookup (CExtend c x t r) x == Just (t, r)" $
+      property specContextLookupAfterExtend
+    it "CExtend em z t r == CExtend (contextLookup em z) z t r" $
+      property specContextExtendAfterLookup
+  describe "effectMapLookup" $ do
+    it "effectMapLookup (EMExtend em z x t r) x == Just (x, t, r)" $
+      property specEffectMapLookupAfterExtend
+    it "EMExtend em z x t r == EMExtend (effectMapLookup em z) z x t r" $
+      property specEffectMapExtendAfterLookup

--- a/implementation/test/Types.hs
+++ b/implementation/test/Types.hs
@@ -1,0 +1,24 @@
+module Types (Effect(..), Variable(..), effects, variables) where
+
+import Test.QuickCheck
+  ( Arbitrary
+  , arbitrary
+  , elements )
+
+data Effect = EffectA | EffectB | EffectC | EffectD | EffectE
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Effect where
+  arbitrary = elements effects
+
+effects :: [Effect]
+effects = [EffectA, EffectB, EffectC, EffectD, EffectE]
+
+data Variable = VarV | VarW | VarX | VarY | VarZ
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Variable where
+  arbitrary = elements variables
+
+variables :: [Variable]
+variables = [VarV, VarW, VarX, VarY, VarZ]


### PR DESCRIPTION
Add specs for `contextLookup` and `effectMapLookup`.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-syntax-specs.pdf) is a link to the PDF generated from this PR.
