### PR TITLE
Align arrows to double colon in type annotations

### DIFF
--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -15,35 +15,35 @@ import Types (Effect(..), Variable(..))
 -- The QuickCheck specs
 
 specContextLookupAfterExtend :: Context Variable Effect
-                                -> Variable
-                                -> Type Effect
-                                -> Row Effect
-                                -> Bool
+                             -> Variable
+                             -> Type Effect
+                             -> Row Effect
+                             -> Bool
 specContextLookupAfterExtend c x t r =
   contextLookup (CExtend c x t r) x == Just (t, r)
 
 specContextExtendAfterLookup :: Context Variable Effect
-                                -> Variable
-                                -> Variable
-                                -> Bool
+                             -> Variable
+                             -> Variable
+                             -> Bool
 specContextExtendAfterLookup c x1 x2 =
   case contextLookup c x1 of
     Just (t, r) -> contextLookup (CExtend c x1 t r) x2 == contextLookup c x2
     Nothing -> True
 
 specEffectMapLookupAfterExtend :: EffectMap Variable Effect
-                                  -> Effect
-                                  -> Variable
-                                  -> Type Effect
-                                  -> Row Effect
-                                  -> Bool
+                               -> Effect
+                               -> Variable
+                               -> Type Effect
+                               -> Row Effect
+                               -> Bool
 specEffectMapLookupAfterExtend em z x t r =
   effectMapLookup (EMExtend em z x t r) z == Just (x, t, r)
 
 specEffectMapExtendAfterLookup :: EffectMap Variable Effect
-                                  -> Effect
-                                  -> Effect
-                                  -> Bool
+                               -> Effect
+                               -> Effect
+                               -> Bool
 specEffectMapExtendAfterLookup em z1 z2 =
   case effectMapLookup em z1 of
     Just (x, t, r) ->


### PR DESCRIPTION
Align function arrows in type annotations to the double colon.