### PR TITLE
Fix subtyping in the paper and implement it in Haskell

### DIFF
--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
   other-modules:       Subrow
+                     , Subtype
                      , Syntax
   build-depends:       base >= 4.7 && < 5
                      , containers
@@ -36,6 +37,7 @@ test-suite implementation-test
   hs-source-dirs:      test
   main-is:             LibSpec.hs
   other-modules:       SubrowSpec
+                     , SubtypeSpec
                      , SyntaxSpec
                      , Types
   build-depends:       base

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -6,9 +6,11 @@ module Lib (
   , Type(..)
   , contextLookup
   , effectMapLookup
-  , subrow ) where
+  , subrow
+  , subtype ) where
 
 import Subrow (subrow)
+import Subtype (subtype)
 import Syntax (
     Term(..)
   , Context(..)

--- a/implementation/src/Subtype.hs
+++ b/implementation/src/Subtype.hs
@@ -1,0 +1,15 @@
+module Subtype (subtype) where
+
+import Data.Maybe (fromJust)
+import Syntax (Row(..), Type(..))
+import Subrow (subrow)
+
+-- This function assumes there are no missing rows in the types.
+subtype :: Ord a => Type a -> Row a -> Type a -> Row a -> Bool
+subtype TUnit r1 TUnit r2 = subrow r1 r2
+subtype TUnit _ _ _ = False
+subtype (TArrow t1 t2 r1) r2 (TArrow t3 t4 r3) r4 =
+     subtype t3 REmpty t1 REmpty
+  && subtype t2 (fromJust r1) t4 (fromJust r3)
+  && subrow r2 r4
+subtype (TArrow _ _ _) _ _ _ = False

--- a/implementation/test/LibSpec.hs
+++ b/implementation/test/LibSpec.hs
@@ -1,4 +1,5 @@
 import SubrowSpec (subrowSpec)
+import SubtypeSpec (subtypeSpec)
 import SyntaxSpec (syntaxSpec)
 import Test.Hspec (hspec)
 
@@ -7,4 +8,5 @@ import Test.Hspec (hspec)
 main :: IO ()
 main = hspec $ do
   subrowSpec
+  subtypeSpec
   syntaxSpec

--- a/implementation/test/SubrowSpec.hs
+++ b/implementation/test/SubrowSpec.hs
@@ -41,8 +41,8 @@ specSubrowImpliesContained r1 r2 =
   contained r1 r2
 
 subrowSpec :: Spec
-subrowSpec = modifyMaxSuccess (const 1000000) $ describe "subrow" $ do
-  it "returns True for r1 <= r2 if r2 contains all the effects in r1" $
+subrowSpec = modifyMaxSuccess (const 100000) $ describe "subrow" $ do
+  it "returns True for r1 <= r2 if r2 contains all the effects in r1" $ do
     property specContainedImpliesSubrow
-  it "returns True for r1 <= r2 implies r2 contains all the effects in r1" $
+  it "returns True for r1 <= r2 implies r2 contains all the effects in r1" $ do
     property specSubrowImpliesContained

--- a/implementation/test/SubtypeSpec.hs
+++ b/implementation/test/SubtypeSpec.hs
@@ -1,0 +1,24 @@
+module SubtypeSpec (subtypeSpec) where
+
+import Lib (Row(..), Type(..), subrow, subtype)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
+import Test.QuickCheck (property)
+import Types (Effect(..))
+
+-- The QuickCheck specs
+
+specMonotonicity :: Type Effect
+                 -> Row Effect
+                 -> Type Effect
+                 -> Row Effect
+                 -> Bool
+specMonotonicity t1 r1 t2 r2 =
+     not (subtype t1 REmpty t2 REmpty || t1 == t2)
+  || not (subrow r1 r2)
+  || subtype t1 r1 t2 r2
+
+subtypeSpec :: Spec
+subtypeSpec = modifyMaxSuccess (const 100000) $ describe "subtype" $ do
+  it "is monotonic with respect to nested subtypes or subrows" $ do
+    property specMonotonicity

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -51,14 +51,14 @@ specEffectMapExtendAfterLookup em z1 z2 =
     Nothing -> True
 
 syntaxSpec :: Spec
-syntaxSpec = modifyMaxSuccess (const 1000000) $ do
+syntaxSpec = modifyMaxSuccess (const 100000) $ do
   describe "contextLookup" $ do
-    it "contextLookup (CExtend c x t r) x == Just (t, r)" $
+    it "contextLookup (CExtend c x t r) x == Just (t, r)" $ do
       property specContextLookupAfterExtend
-    it "CExtend em z t r == CExtend (contextLookup em z) z t r" $
+    it "CExtend em z t r == CExtend (contextLookup em z) z t r" $ do
       property specContextExtendAfterLookup
   describe "effectMapLookup" $ do
-    it "effectMapLookup (EMExtend em z x t r) x == Just (x, t, r)" $
+    it "effectMapLookup (EMExtend em z x t r) x == Just (x, t, r)" $ do
       property specEffectMapLookupAfterExtend
-    it "EMExtend em z x t r == EMExtend (effectMapLookup em z) z x t r" $
+    it "EMExtend em z x t r == EMExtend (effectMapLookup em z) z x t r" $ do
       property specEffectMapExtendAfterLookup

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -183,12 +183,11 @@
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\subtype{\type_3}{\type_1}$}
-              \AxiomC{$\subtype{\type_2}{\type_4}$}
-              \AxiomC{$\subrow{\row_1}{\row_3}$}
+              \AxiomC{$\subtype{\tEmbellished{\type_3}{\rEmpty}}{\tEmbellished{\type_1}{\rEmpty}}$}
+              \AxiomC{$\subtype{\tEmbellished{\type_2}{\row_1}}{\tEmbellished{\type_4}{\row_3}}$}
               \AxiomC{$\subrow{\row_2}{\row_4}$}
             \RightLabel{(\textsc{ST-Arrow})}
-            \QuaternaryInfC{$\subtype{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}{\tEmbellished{\parens{\tArrow{\type_3}{\tEmbellished{\type_4}{\row_3}}}}{\row_4}}$}
+            \TrinaryInfC{$\subtype{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}{\tEmbellished{\parens{\tArrow{\type_3}{\tEmbellished{\type_4}{\row_3}}}}{\row_4}}$}
           \end{prooftree}
 
           \caption{Subtyping rules}\label{fig:subtyping_rules}


### PR DESCRIPTION
Fix subtyping in the paper and implement it in Haskell.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subtype.pdf) is a link to the PDF generated from this PR.
