### PR TITLE
Remove the subrow part of the subtype relation

### DIFF
--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -59,7 +59,8 @@ infer c em (EProvide z1 zs e1 e2) Nothing Nothing =
          substitutedType = substituteEffectsInType substitution t1
          substitutedRow = substituteEffectsInRow substitution r1
      (_, t2, r2) <- effectMapLookup em z1
-     assert (subtype substitutedType substitutedRow t2 r2)
+     assert (subtype substitutedType t2)
+     assert (subrow substitutedRow r2)
      (t3, r3) <- infer c em e2 Nothing Nothing
      return (t3, (addEffectsToRow (RDifference r3 (RSingleton z1)) zs))
 -- EAnno
@@ -67,7 +68,7 @@ infer c em (EAnno e t r) Nothing Nothing = infer c em e (Just t) (Just r)
 -- Subsumption
 infer c em e (Just t1) Nothing =
   do (t2, r) <- infer c em e Nothing Nothing
-     assert (subtype t2 REmpty t1 REmpty)
+     assert (subtype t2 t1)
      return (t1, r)
 infer c em e Nothing (Just r1) =
   do (t, r2) <- infer c em e Nothing Nothing
@@ -76,10 +77,11 @@ infer c em e Nothing (Just r1) =
 infer c em e (Just t1) (Just r1) =
   if all (== Nothing)
     [ do (_, r2) <- infer c em e (Just t1) Nothing
-         assert (subtype t1 r2 t1 r1)
+         assert (subrow r2 r1)
     , do (t2, _) <- infer c em e Nothing (Just r1)
-         assert (subtype t2 r1 t1 r1)
+         assert (subtype t2 t1)
     , do (t2, r2) <- infer c em e Nothing Nothing
-         assert (subtype t2 r2 t1 r1) ]
+         assert (subtype t2 t1)
+         assert (subrow r2 r1) ]
   then Nothing
   else Just (t1, r1)

--- a/implementation/src/Subtype.hs
+++ b/implementation/src/Subtype.hs
@@ -1,13 +1,13 @@
 module Subtype (subtype) where
 
 import Subrow (subrow)
-import Syntax (Row(..), Type(..))
+import Syntax (Type(..))
 
-subtype :: Ord a => Type a -> Row a -> Type a -> Row a -> Bool
-subtype TUnit r1 TUnit r2 = subrow r1 r2
-subtype TUnit _ _ _ = False
-subtype (TArrow t1 t2 r1) r2 (TArrow t3 t4 r3) r4 =
-     subtype t3 REmpty t1 REmpty
-  && subtype t2 r1 t4 r3
-  && subrow r2 r4
-subtype (TArrow _ _ _) _ _ _ = False
+subtype :: Ord a => Type a -> Type a -> Bool
+subtype TUnit TUnit = True
+subtype TUnit _ = False
+subtype (TArrow t1 t2 r1) (TArrow t3 t4 r2) =
+     subtype t3 t1
+  && subtype t2 t4
+  && subrow r1 r2
+subtype (TArrow _ _ _) _ = False

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -7,6 +7,7 @@ import Lib
   , Term(..)
   , Type(..)
   , infer
+  , subrow
   , subtype )
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Types (Effect(..), Variable(..))
@@ -21,7 +22,9 @@ specTypeCheck e t1 r1 =
   let c = CEmpty :: Context Variable Effect
       em = EMEmpty :: EffectMap Variable Effect
   in case infer c em e Nothing Nothing of
-    Just (t2, r2) -> subtype t2 r2 t1 r1 `shouldBe` True
+    Just (t2, r2) -> do
+      subtype t2 t1 `shouldBe` True
+      subrow r2 r1 `shouldBe` True
     _ -> True `shouldBe` False
 
 inferenceSpec :: Spec

--- a/implementation/test/SubtypeSpec.hs
+++ b/implementation/test/SubtypeSpec.hs
@@ -1,6 +1,6 @@
 module SubtypeSpec (subtypeSpec) where
 
-import Lib (Row(..), Type(..), subrow, subtype)
+import Lib (Type(..), subtype)
 import Test.Hspec (Spec, describe, it)
 import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
 import Test.QuickCheck (property)
@@ -8,17 +8,18 @@ import Types (Effect(..))
 
 -- The QuickCheck specs
 
-specMonotonicity :: Type Effect
-                 -> Row Effect
-                 -> Type Effect
-                 -> Row Effect
-                 -> Bool
-specMonotonicity t1 r1 t2 r2 =
-     not (subtype t1 REmpty t2 REmpty || t1 == t2)
-  || not (subrow r1 r2)
-  || subtype t1 r1 t2 r2
+specReflexivity :: Type Effect -> Type Effect -> Bool
+specReflexivity t1 t2 = not (t1 == t2) || subtype t1 t2
+
+specTransitivity :: Type Effect -> Type Effect -> Type Effect -> Bool
+specTransitivity t1 t2 t3 =
+     not (subtype t1 t2)
+  || not (subtype t2 t3)
+  || subtype t1 t3
 
 subtypeSpec :: Spec
 subtypeSpec = modifyMaxSuccess (const 100000) $ describe "subtype" $ do
-  it "is monotonic with respect to nested subtypes or subrows" $ do
-    property specMonotonicity
+  it "is a reflexive relation" $ do
+    property specReflexivity
+  it "is a transitive relation" $ do
+    property specTransitivity

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -171,23 +171,23 @@
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]
           \begin{center}
-            \framebox{$\subtype{\tEmbellished{\type}{\row}}{\tEmbellished{\type}{\row}}$}
+            \framebox{$\subtype{\type}{\type}$}
           \end{center}
 
           \medskip
 
           \begin{prooftree}
-              \AxiomC{$\subrow{\row_1}{\row_2}$}
+              \AxiomC{}
             \RightLabel{(\textsc{ST-Unit})}
-            \UnaryInfC{$\subtype{\tEmbellished{\tUnit}{\row_1}}{\tEmbellished{\tUnit}{\row_2}}$}
+            \UnaryInfC{$\subtype{\tUnit}{\tUnit}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\subtype{\tEmbellished{\type_3}{\rEmpty}}{\tEmbellished{\type_1}{\rEmpty}}$}
-              \AxiomC{$\subtype{\tEmbellished{\type_2}{\row_1}}{\tEmbellished{\type_4}{\row_3}}$}
-              \AxiomC{$\subrow{\row_2}{\row_4}$}
+              \AxiomC{$\subtype{\type_3}{\type_1}$}
+              \AxiomC{$\subtype{\type_2}{\type_4}$}
+              \AxiomC{$\subrow{\row_1}{\row_2}$}
             \RightLabel{(\textsc{ST-Arrow})}
-            \TrinaryInfC{$\subtype{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}{\tEmbellished{\parens{\tArrow{\type_3}{\tEmbellished{\type_4}{\row_3}}}}{\row_4}}$}
+            \TrinaryInfC{$\subtype{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}{\tArrow{\type_3}{\tEmbellished{\type_4}{\row_2}}}$}
           \end{prooftree}
 
           \caption{Subtyping rules}\label{fig:subtyping_rules}
@@ -225,18 +225,21 @@
           \begin{prooftree}
               \AxiomC{$\hasType{\context}{\term_1}{\tEmbellished{\type_1}{\row_1}}$}
               \AxiomC{$\hasType{\context}{\term_2}{\tEmbellished{\parens{\tArrow{\type_3}{\tEmbellished{\type_2}{\row_2}{}}}}{\row_3}}$}
-              \AxiomC{$\subtype{\tEmbellished{\type_1}{\rEmpty}}{\tEmbellished{\type_3}{\rEmpty}}$}
+              \AxiomC{$\subtype{\type_1}{\type_3}$}
             \RightLabel{(\textsc{T-Application})}
             \TrinaryInfC{$\hasType{\context}{\eApp{\term_2}{\term_1}}{\tEmbellished{\type_2}{\rUnion{\rUnion{\row_1}{\row_2}}{\row_3}}}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\hasType{\context}{\term_1}{\tEmbellished{\type_1}{\row_1}}$}
-              \AxiomC{$\hasType{\context}{\term_2}{\tEmbellished{\type_2}{\row_2}}$}
-              \AxiomC{$\apply{\effectMap}{\effect} = \anno{\eVar}{\tEmbellished{\type_3}{\row_3}}$}
-              \AxiomC{$\subtype{\tEmbellished{\substitute{\type_1}{\effect_i}{\effect}}{\substitute{\row_1}{\effect_i}{\effect}}}{\tEmbellished{\type_3}{\row_3}}$}
+              \AxiomC{\Shortstack[c]{
+                {$\hasType{\context}{\term_1}{\tEmbellished{\type_1}{\row_1}}$}
+                {$\hasType{\context}{\term_2}{\tEmbellished{\type_2}{\row_2}}$}
+                {$\subtype{\substitute{\type_1}{\effect_i}{\effect}}{\type_3}$}
+                {$\subrow{\substitute{\row_1}{\effect_i}{\effect}}{\row_3}$}
+                {$\apply{\effectMap}{\effect} = \anno{\eVar}{\tEmbellished{\type_3}{\row_3}}$}
+              }}
             \RightLabel{(\textsc{T-Provide})}
-            \QuaternaryInfC{$\hasType{\context}{\eProvide{\effect}{\overline{\effect_i}}{\term_1}{\term_2}}{\tEmbellished{\type_2}{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\effect_i}}}$}
+            \UnaryInfC{$\hasType{\context}{\eProvide{\effect}{\overline{\effect_i}}{\term_1}{\term_2}}{\tEmbellished{\type_2}{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\effect_i}}}$}
           \end{prooftree}
 
           \caption{Typing rules}\label{fig:typing_rules}


### PR DESCRIPTION
Remove the subrow part of the subtype relation, because there is already a separate subrow relation. This change applies to the Haskell implementation and the LaTeX writeup, but not the Coq scripts because we haven't defined this relation there.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-subtyping.pdf) is a link to the PDF generated from this PR.
