### PR TITLE
Refactor the bidirectional inference algorithm into 4 mutually recursive functions

### DIFF
--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,4 +1,8 @@
-module Inference (infer) where
+module Inference
+  ( checkTypeAndRow
+  , checkTypeInferRow
+  , inferTypeAndRow
+  , inferTypeCheckRow ) where
 
 import Subrow (subrow)
 import Subtype (subtype)
@@ -24,64 +28,84 @@ addEffectsToRow r [] = r
 addEffectsToRow r (x : []) = RUnion (RSingleton x) r
 addEffectsToRow r (x : xs) = RUnion (RSingleton x) (addEffectsToRow r xs)
 
--- Type and effect row inference
+-- Infer the type and row
 
-infer :: (Ord a, Ord b)
-      => Context a b
-      -> EffectMap a b
-      -> Term a b
-      -> Maybe (Type b)
-      -> Maybe (Row b)
-      -> Maybe (Type b, Row b)
--- EUnit
-infer _ _ EUnit Nothing Nothing = return (TUnit, REmpty)
--- EVar
-infer c _ (EVar x) Nothing Nothing =
-  do (t, r) <- contextLookup c x
-     return (t, r)
--- EAbs
-infer c em (EAbs x e) (Just (TArrow t1 t2 r)) Nothing =
-  do _ <- infer (CExtend c x t1 REmpty) em e (Just t2) (Just r)
-     return ((TArrow t1 t2 r), REmpty)
-infer _ _ (EAbs _ _) _ Nothing = Nothing
--- EApp
-infer c em (EApp e1 e2) Nothing Nothing =
-  do (t1, r1) <- infer c em e1 Nothing Nothing
+inferTypeAndRow :: (Ord a, Ord b)
+                => Context a b
+                -> EffectMap a b
+                -> Term a b
+                -> Maybe (Type b, Row b)
+inferTypeAndRow _ _ EUnit = return (TUnit, REmpty)
+inferTypeAndRow c _ (EVar x) = contextLookup c x
+inferTypeAndRow _ _ (EAbs _ _) = Nothing
+inferTypeAndRow c em (EApp e1 e2) =
+  do (t1, r1) <- inferTypeAndRow c em e1
      case t1 of
        TArrow t2 t3 r2 ->
-         do (_, r3) <- infer c em e2 (Just t2) Nothing
+         do r3 <- checkTypeInferRow c em e2 t2
             return (t3, (RUnion r1 (RUnion r2 r3)))
        _ -> Nothing
--- EProvide
-infer c em (EProvide z1 zs e1 e2) Nothing Nothing =
-  do (t1, r1) <- infer c em e1 Nothing Nothing
+inferTypeAndRow c em (EProvide z1 zs e1 e2) =
+  do (t1, r1) <- inferTypeAndRow c em e1
      let substitution = Map.fromList [ (z2, z1) | z2 <- zs ]
          substitutedType = substituteEffectsInType substitution t1
          substitutedRow = substituteEffectsInRow substitution r1
      (_, t2, r2) <- effectMapLookup em z1
      assert (subtype substitutedType t2)
      assert (subrow substitutedRow r2)
-     (t3, r3) <- infer c em e2 Nothing Nothing
+     (t3, r3) <- inferTypeAndRow c em e2
      return (t3, (addEffectsToRow (RDifference r3 (RSingleton z1)) zs))
--- EAnno
-infer c em (EAnno e t r) Nothing Nothing = infer c em e (Just t) (Just r)
--- Subsumption
-infer c em e (Just t1) Nothing =
-  do (t2, r) <- infer c em e Nothing Nothing
-     assert (subtype t2 t1)
-     return (t1, r)
-infer c em e Nothing (Just r1) =
-  do (t, r2) <- infer c em e Nothing Nothing
+inferTypeAndRow c em (EAnno e t r) =
+  do checkTypeAndRow c em e t r
+     return (t, r)
+
+-- Infer the type, check the row
+
+inferTypeCheckRow :: (Ord a, Ord b)
+                  => Context a b
+                  -> EffectMap a b
+                  -> Term a b
+                  -> Row b
+                  -> Maybe (Type b)
+inferTypeCheckRow c em e r1 =
+  do (t, r2) <- inferTypeAndRow c em e
      assert (subrow r2 r1)
-     return (t, r1)
-infer c em e (Just t1) (Just r1) =
+     return t
+
+-- Check the type, infer the row
+
+checkTypeInferRow :: (Ord a, Ord b)
+                  => Context a b
+                  -> EffectMap a b
+                  -> Term a b
+                  -> Type b
+                  -> Maybe (Row b)
+checkTypeInferRow c em (EAbs x e) (TArrow t1 t2 r) =
+  do checkTypeAndRow (CExtend c x t1 REmpty) em e t2 r
+     return REmpty
+checkTypeInferRow _ _ (EAbs _ _) _ = Nothing
+checkTypeInferRow c em e t1 =
+  do (t2, r) <- inferTypeAndRow c em e
+     assert (subtype t2 t1)
+     return r
+
+-- Check the type and row
+
+checkTypeAndRow :: (Ord a, Ord b)
+                => Context a b
+                -> EffectMap a b
+                -> Term a b
+                -> Type b
+                -> Row b
+                -> Maybe ()
+checkTypeAndRow c em e t1 r1 =
   if all (== Nothing)
-    [ do (_, r2) <- infer c em e (Just t1) Nothing
+    [ do r2 <- checkTypeInferRow c em e t1
          assert (subrow r2 r1)
-    , do (t2, _) <- infer c em e Nothing (Just r1)
+    , do t2 <- inferTypeCheckRow c em e r1
          assert (subtype t2 t1)
-    , do (t2, r2) <- infer c em e Nothing Nothing
+    , do (t2, r2) <- inferTypeAndRow c em e
          assert (subtype t2 t1)
          assert (subrow r2 r1) ]
   then Nothing
-  else Just (t1, r1)
+  else Just ()

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -4,15 +4,22 @@ module Lib
   , Row(..)
   , Term(..)
   , Type(..)
+  , checkTypeAndRow
+  , checkTypeInferRow
   , contextLookup
   , effectMapLookup
-  , infer
+  , inferTypeAndRow
+  , inferTypeCheckRow
   , subrow
   , substituteEffectsInRow
   , substituteEffectsInType
   , subtype ) where
 
-import Inference (infer)
+import Inference
+  ( checkTypeAndRow
+  , checkTypeInferRow
+  , inferTypeAndRow
+  , inferTypeCheckRow )
 import Subrow (subrow)
 import Subtype (subtype)
 import Syntax

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -6,7 +6,7 @@ import Lib
   , Row(..)
   , Term(..)
   , Type(..)
-  , infer
+  , inferTypeAndRow
   , subrow
   , subtype )
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
@@ -21,7 +21,7 @@ specTypeCheck :: Term Variable Effect
 specTypeCheck e t1 r1 =
   let c = CEmpty :: Context Variable Effect
       em = EMEmpty :: EffectMap Variable Effect
-  in case infer c em e Nothing Nothing of
+  in case inferTypeAndRow c em e of
     Just (t2, r2) -> do
       subtype t2 t1 `shouldBe` True
       subrow r2 r1 `shouldBe` True


### PR DESCRIPTION
Refactor the inference algorithm into 4 mutually recursive functions. This is a more faithful extension of the traditional bidirectional type inference algorithm. I think it will be easier to formalize this way (both in LaTeX and in Coq). Also, now there are no functions which return more things than necessary (for example, in the previous version, calling `infer` in inference mode would return unmodified the type/row that you passed in).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-inference-refactor.pdf) is a link to the PDF generated from this PR.
