### PR TITLE
Prevent recursion in provide

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -263,8 +263,8 @@
               \AxiomC{\Shortstack[c]{
                 {$\hasType{\context}{\term_1}{\tEmbellished{\type_1}{\row_1}}$}
                 {$\hasType{\context}{\term_2}{\tEmbellished{\type_2}{\row_2}}$}
-                {$\subtype{\substitute{\type_1}{\effect_i}{\effect}}{\type_3}$}
-                {$\subrow{\substitute{\row_1}{\effect_i}{\effect}}{\row_3}$}
+                {$\subtype{\type_1}{\substitute{\type_3}{\effect}{\effect_i}}$}
+                {$\subrow{\row_1}{\substitute{\row_3}{\effect}{\effect_i}}$}
                 {$\apply{\effectMap}{\effect} = \anno{\eVar}{\tEmbellished{\type_3}{\row_3}}$}
               }}
             \RightLabel{(\textsc{T-Provide})}


### PR DESCRIPTION
With the previous typing rule, recursion was implicitly baked into the type system. For instance, we could type the expression

```
provide Log / []
with
  log = \s -> log s
in
...
```

After this change, if the effect being provided occurs in the type of the implementation, but not in the `using` list, the `provide` will not be well-typed. This change imposes no significant new restrictions because the programmer can still reuse the implementation currently being provided by storing the implementation in a variable outside the provide.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-fix-substitution-provide.pdf) is a link to the PDF generated from this PR.
