### PR TITLE
Let the effect map map an effect to a variable rather than an embellished type

### DIFF
--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -32,7 +32,7 @@ addEffectsToRow r (x : xs) = RUnion (RSingleton x) (addEffectsToRow r xs)
 
 inferTypeAndRow :: (Ord a, Ord b)
                 => Context a b
-                -> EffectMap b
+                -> EffectMap a b
                 -> Term a b
                 -> Maybe (Type b, Row b)
 inferTypeAndRow _ _ EUnit = return (TUnit, REmpty)
@@ -46,9 +46,10 @@ inferTypeAndRow c em (EApp e1 e2) =
             return (t3, (RUnion r1 (RUnion r2 r3)))
        _ -> Nothing
 inferTypeAndRow c em (EProvide z zs e1 e2) =
-  do (t1, r1) <- inferTypeAndRow c em e1
+  do x <- effectMapLookup em z
+     (t1, r1) <- inferTypeAndRow c em e1
      (t2, r2) <- inferTypeAndRow c em e2
-     (t3, r3) <- effectMapLookup em z
+     (t3, r3) <- contextLookup c x
      let substitution = Map.singleton z (addEffectsToRow REmpty zs)
          substitutedType = substituteEffectsInType substitution t3
          substitutedRow = substituteEffectsInRow substitution r3
@@ -63,7 +64,7 @@ inferTypeAndRow c em (EAnno e t r) =
 
 inferTypeCheckRow :: (Ord a, Ord b)
                   => Context a b
-                  -> EffectMap b
+                  -> EffectMap a b
                   -> Term a b
                   -> Row b
                   -> Maybe (Type b)
@@ -76,7 +77,7 @@ inferTypeCheckRow c em e r1 =
 
 checkTypeInferRow :: (Ord a, Ord b)
                   => Context a b
-                  -> EffectMap b
+                  -> EffectMap a b
                   -> Term a b
                   -> Type b
                   -> Maybe (Row b)
@@ -93,7 +94,7 @@ checkTypeInferRow c em e t1 =
 
 checkTypeAndRow :: (Ord a, Ord b)
                 => Context a b
-                -> EffectMap b
+                -> EffectMap a b
                 -> Term a b
                 -> Type b
                 -> Row b

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -20,7 +20,7 @@ specTypeCheck :: Term Variable Effect
               -> Expectation
 specTypeCheck e t1 r1 =
   let c = CEmpty :: Context Variable Effect
-      em = EMEmpty :: EffectMap Effect
+      em = EMEmpty :: EffectMap Variable Effect
   in case inferTypeAndRow c em e of
     Just (t2, r2) -> do
       subtype t2 t1 `shouldBe` True

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -31,22 +31,21 @@ specContextExtendAfterLookup c x1 x2 =
     Just (t, r) -> contextLookup (CExtend c x1 t r) x2 == contextLookup c x2
     Nothing -> True
 
-specEffectMapLookupAfterExtend :: EffectMap Effect
+specEffectMapLookupAfterExtend :: EffectMap Variable Effect
                                -> Effect
-                               -> Type Effect
-                               -> Row Effect
+                               -> Variable
                                -> Bool
-specEffectMapLookupAfterExtend em z t r =
-  effectMapLookup (EMExtend em z t r) z == Just (t, r)
+specEffectMapLookupAfterExtend em z x =
+  effectMapLookup (EMExtend em z x) z == Just x
 
-specEffectMapExtendAfterLookup :: EffectMap Effect
+specEffectMapExtendAfterLookup :: EffectMap Variable Effect
                                -> Effect
                                -> Effect
                                -> Bool
 specEffectMapExtendAfterLookup em z1 z2 =
   case effectMapLookup em z1 of
-    Just (t, r) ->
-      effectMapLookup (EMExtend em z1 t r) z2 == effectMapLookup em z2
+    Just x ->
+      effectMapLookup (EMExtend em z1 x) z2 == effectMapLookup em z2
     Nothing -> True
 
 syntaxSpec :: Spec
@@ -54,10 +53,10 @@ syntaxSpec = modifyMaxSuccess (const 100000) $ do
   describe "contextLookup" $ do
     it "contextLookup (CExtend c x t r) x == Just (t, r)" $ do
       property specContextLookupAfterExtend
-    it "CExtend em z t r == CExtend (contextLookup em z) z t r" $ do
+    it "CExtend em x t r == CExtend (contextLookup em x) x t r" $ do
       property specContextExtendAfterLookup
   describe "effectMapLookup" $ do
-    it "effectMapLookup (EMExtend em z t r) x == Just (x, t, r)" $ do
+    it "effectMapLookup (EMExtend em z x) z == Just x" $ do
       property specEffectMapLookupAfterExtend
-    it "EMExtend em z x t r == EMExtend (effectMapLookup em z) z x t r" $ do
+    it "EMExtend em z x == EMExtend (effectMapLookup em z) z x" $ do
       property specEffectMapExtendAfterLookup

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -96,7 +96,7 @@
 % Effect map
 \newcommand\effect{e}
 \newcommand\effectMap{E}
-\newcommand\emMap[2]{#1 :: #2}
+\newcommand\emMap[2]{#1 \mapsto #2}
 \newcommand\emEmpty{\varnothing_{\effectMap}}
 \newcommand\emExtend[2]{#1, #2}
 
@@ -106,7 +106,7 @@
 \newcommand\subrow[2]{#1 \subrowSym #2}
 \newcommand\subtype[2]{#1 \subtypeSym #2}
 \newcommand\hasType[3]{#1 \vdash \anno{#2}{#3}}
-\newcommand\eWellFormed[1]{#1 \; \text{well-formed effect}}
+\newcommand\eWellFormed[2]{#1 \vdash #2}
 
 %%%%%%%%%%%%%%%%%%%%%
 % The specification %
@@ -166,7 +166,7 @@
               \\
               $\effectMap \Coloneqq$ & & effect map: \\
               & $\emEmpty$ & empty effect map \\
-              & $\emExtend{\effectMap}{\emMap{\effect}{\tEmbellished{\type}{\row}}}$ & effect binding \\
+              & $\emExtend{\effectMap}{\emMap{\effect}{\eVar}}$ & effect binding \\
             \end{tabular}
           \end{center}
 
@@ -263,9 +263,9 @@
               \AxiomC{\Shortstack[c]{
                 {$\hasType{\context}{\term_1}{\tEmbellished{\type_1}{\row_1}}$}
                 {$\hasType{\context}{\term_2}{\tEmbellished{\type_2}{\row_2}}$}
+                {$\hasType{\context}{\apply{\effectMap}{\effect}}{\tEmbellished{\type_3}{\row_3}}$}
                 {$\subtype{\type_1}{\substitute{\type_3}{\rSingleton{\effect}}{\bigcup_i \effect_i}}$}
                 {$\subrow{\row_1}{\substitute{\row_3}{\rSingleton{\effect}}{\bigcup_i \effect_i}}$}
-                {$\apply{\effectMap}{\effect} = \tEmbellished{\type_3}{\row_3}$}
               }}
             \RightLabel{(\textsc{T-Provide})}
             \UnaryInfC{$\hasType{\context}{\eProvide{\effect}{\overline{\effect_i}}{\term_1}{\term_2}}{\tEmbellished{\type_2}{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\effect_i}}}$}
@@ -278,27 +278,30 @@
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]
           \begin{center}
-            \framebox{$\eWellFormed{\emMap{\effect}{\tEmbellished{\type}{\row}}}$}
+            \framebox{$\eWellFormed{\context}{\emMap{\effect}{\eVar}}$}
           \end{center}
 
           \medskip
 
           \begin{prooftree}
-              \AxiomC{$\effect \in \row$}
+              \AxiomC{$\hasType{\context}{\eVar}{\tEmbellished{\tUnit}{\row}}$}
+              \AxiomC{$\subrow{\rSingleton{\effect}}{\row}$}
             \RightLabel{(\textsc{WFE-Unit})}
-            \UnaryInfC{$\eWellFormed{\emMap{\effect}{\tEmbellished{\tUnit}{\row}}}$}
+            \BinaryInfC{$\eWellFormed{\context}{\emMap{\effect}{\eVar}}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\effect \in \row_2$}
+              \AxiomC{$\hasType{\context}{\eVar}{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}$}
+              \AxiomC{$\subrow{\rSingleton{\effect}}{\row_2}$}
             \RightLabel{(\textsc{WFE-Arrow1})}
-            \UnaryInfC{$\eWellFormed{\emMap{\effect}{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}}$}
+            \BinaryInfC{$\eWellFormed{\context}{\emMap{\effect}{\eVar}}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\eWellFormed{\emMap{\effect}{\tEmbellished{\type_2}{\row_1}}}$}
+              \AxiomC{$\hasType{\context}{\eVar_1}{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}$}
+              \AxiomC{$\eWellFormed{\cExtend{\context}{\anno{\eVar_2}{\tEmbellished{\type_2}{\row_1}}}}{\emMap{\effect}{\eVar_2}}$}
             \RightLabel{(\textsc{WFE-Arrow2})}
-            \UnaryInfC{$\eWellFormed{\emMap{\effect}{\tEmbellished{\parens{\tArrow{\type_1}{\tEmbellished{\type_2}{\row_1}}}}{\row_2}}}$}
+            \BinaryInfC{$\eWellFormed{\context}{\emMap{\effect}{\eVar_1}}$}
           \end{prooftree}
 
           \caption{Effect well-formedness}\label{fig:effect_well_formedness}


### PR DESCRIPTION
Let the effect map map an effect to a variable rather than an embellished type.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-effect-map.pdf) is a link to the PDF generated from this PR.
