### PR TITLE
Use \Sigma instead of E for the effect map

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -95,7 +95,7 @@
 
 % Effect map
 \newcommand\effect{e}
-\newcommand\effectMap{E}
+\newcommand\effectMap{\Sigma}
 \newcommand\emMap[2]{#1 \mapsto #2}
 \newcommand\emEmpty{\varnothing_{\effectMap}}
 \newcommand\emExtend[2]{#1, #2}


### PR DESCRIPTION
Use `\Sigma` instead of `E` for the effect map. This matches Pretnar's [tutorial](http://www.eff-lang.org/handlers-tutorial.pdf) and looks a little nicer IMO.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-sigma.pdf) is a link to the PDF generated from this PR.
