### PR TITLE
Remove the confusing subscripts from the \varnothing constructors

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -73,7 +73,7 @@
 
 % Rows
 \newcommand\row{\varepsilon}
-\newcommand\rEmpty{\varnothing_{\row}}
+\newcommand\rEmpty{\varnothing}
 \newcommand\rSingleton[1]{\left\{ #1 \right\}}
 \newcommand\rUnion[2]{#1 \cup #2}
 \newcommand\rDiff[2]{#1 \setminus #2}
@@ -90,14 +90,14 @@
 
 % Type contexts
 \newcommand\context{\Gamma}
-\newcommand\cEmpty{\varnothing_{\context}}
+\newcommand\cEmpty{\varnothing}
 \newcommand\cExtend[2]{#1, #2}
 
 % Effect map
 \newcommand\effect{e}
 \newcommand\effectMap{\Sigma}
 \newcommand\emMap[2]{#1 \mapsto #2}
-\newcommand\emEmpty{\varnothing_{\effectMap}}
+\newcommand\emEmpty{\varnothing}
 \newcommand\emExtend[2]{#1, #2}
 
 % Judgments


### PR DESCRIPTION
Remove the confusing subscripts from the `\varnothing` constructors. Hopefully things will be clear from context (no pun intended). We'll keep the separate macros in case we later discover an elegant way to syntactically distinguish between these constructors.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-varnothing.pdf) is a link to the PDF generated from this PR.
