### PR TITLE
Add a well-formedness figure for effect contexts

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -107,6 +107,7 @@
 \newcommand\subtype[2]{#1 \subtypeSym #2}
 \newcommand\hasType[3]{#1 \vdash \anno{#2}{#3}}
 \newcommand\eWellFormed[2]{#1 \vdash #2}
+\newcommand\initWellFormed[2]{#1; #2 \; \text{initial}}
 
 %%%%%%%%%%%%%%%%%%%%%
 % The specification %
@@ -305,6 +306,31 @@
           \end{prooftree}
 
           \caption{Effect well-formedness}\label{fig:effect_well_formedness}
+        \end{mdframed}
+      \end{figure}
+
+      \begin{figure}[H]
+        \begin{mdframed}[backgroundcolor=none]
+          \begin{center}
+            \framebox{$\initWellFormed{\context}{\effectMap}$}
+          \end{center}
+
+          \medskip
+
+          \begin{prooftree}
+              \AxiomC{}
+            \RightLabel{(\textsc{INIT-Empty})}
+            \UnaryInfC{$\initWellFormed{\cEmpty}{\emEmpty}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\initWellFormed{\context}{\effectMap}$}
+              \AxiomC{$\eWellFormed{\cExtend{\context}{\anno{\eVar}{\tEmbellished{\type}{\row}}}}{\emMap{\effect}{\eVar}}$}
+            \RightLabel{(\textsc{INIT-Extension})}
+            \BinaryInfC{$\initWellFormed{\cExtend{\context}{\anno{\eVar}{\tEmbellished{\type}{\row}}}}{\emExtend{\effectMap}{\emMap{\effect}{\eVar}}}$}
+          \end{prooftree}
+
+          \caption{Initial type and effect context well-formedness}\label{fig:context_well_formedness}
         \end{mdframed}
       \end{figure}
 


### PR DESCRIPTION
Add a well-formedness figure for effect contexts. I am not sure if we want this, but it seems incomplete without it.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-wfc.pdf) is a link to the PDF generated from this PR.
