### PR TITLE
Document the inference algorithm in the paper

### DIFF
--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -1,5 +1,3 @@
-Require Import Coq.Lists.List.
-
 (* Identifiers *)
 
 Module Type Identifiers.
@@ -21,9 +19,10 @@ Module Syntax (IdentifiersInstance : Identifiers).
   Inductive term : Type :=
   | eUnit : term
   | eVar : termId -> term
-  | eAbs : termId -> type -> term -> term
+  | eAbs : termId -> term -> term
   | eApp : term -> term -> term
-  | eHandle : effectId -> list effectId -> term -> term -> term
+  | eHandle : effectId -> row -> term -> term -> term
+  | eAnno : term -> type -> row -> term
 
   (* Proper types *)
 

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -16,7 +16,8 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Lib
-  other-modules:       Inference
+  other-modules:       Error
+                     , Inference
                      , Subrow
                      , Subtype
                      , Syntax
@@ -37,7 +38,8 @@ test-suite implementation-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             LibSpec.hs
-  other-modules:       InferenceSpec
+  other-modules:       ErrorSpec
+                     , InferenceSpec
                      , SubrowSpec
                      , SubtypeSpec
                      , SyntaxSpec

--- a/implementation/src/Error.hs
+++ b/implementation/src/Error.hs
@@ -1,0 +1,22 @@
+module Error
+  ( Partial
+  , abort
+  , assert
+  , maybeToPartial
+  , partialToMaybe ) where
+
+type Partial a = Either String a
+
+abort :: String -> Partial a
+abort s = Left s
+
+assert :: Bool -> String -> Partial ()
+assert b s = if b then return () else abort s
+
+maybeToPartial :: Maybe a -> String -> Partial a
+maybeToPartial (Just x) _ = return x
+maybeToPartial Nothing s = abort s
+
+partialToMaybe :: Partial a -> Maybe a
+partialToMaybe (Right x) = return x
+partialToMaybe (Left _) = Nothing

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -1,20 +1,31 @@
 module Lib
   ( Context(..)
   , EffectMap(..)
+  , Partial
   , Row(..)
   , Term(..)
   , Type(..)
+  , abort
+  , assert
   , checkTypeAndRow
   , checkTypeInferRow
   , contextLookup
   , effectMapLookup
   , inferTypeAndRow
   , inferTypeCheckRow
+  , maybeToPartial
+  , partialToMaybe
   , subrow
   , substituteEffectsInRow
   , substituteEffectsInType
   , subtype ) where
 
+import Error
+  ( Partial
+  , abort
+  , assert
+  , maybeToPartial
+  , partialToMaybe )
 import Inference
   ( checkTypeAndRow
   , checkTypeInferRow

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -26,7 +26,7 @@ data Term a b -- Metavariable: e
   | EVar a
   | EAbs a (Term a b)
   | EApp (Term a b) (Term a b)
-  | EHandle b [b] (Term a b) (Term a b)
+  | EHandle b (Row b) (Term a b) (Term a b)
   | EAnno (Term a b) (Type b) (Row b)
   deriving (Eq, Show)
 

--- a/implementation/test/ErrorSpec.hs
+++ b/implementation/test/ErrorSpec.hs
@@ -1,0 +1,9 @@
+module ErrorSpec (errorSpec) where
+
+import Test.Hspec (Spec, describe, it, pending)
+
+-- The QuickCheck specs
+
+errorSpec :: Spec
+errorSpec = describe "error" $
+  it "should be correct" $ pending

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -22,7 +22,7 @@ specTypeCheck e t1 r1 =
   let c = CEmpty :: Context Variable Effect
       em = EMEmpty :: EffectMap Variable Effect
   in case inferTypeAndRow c em e of
-    Just (t2, r2) -> do
+    Right (t2, r2) -> do
       subtype t2 t1 `shouldBe` True
       subrow r2 r1 `shouldBe` True
     _ -> True `shouldBe` False

--- a/implementation/test/LibSpec.hs
+++ b/implementation/test/LibSpec.hs
@@ -1,3 +1,4 @@
+import ErrorSpec (errorSpec)
 import InferenceSpec (inferenceSpec)
 import SubrowSpec (subrowSpec)
 import SubtypeSpec (subtypeSpec)
@@ -8,6 +9,7 @@ import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec $ do
+  errorSpec
   inferenceSpec
   subrowSpec
   subtypeSpec

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -55,9 +55,9 @@
 \newcommand\anno[2]{#1 : #2}
 \newcommand\apply[2]{#1\parens{#2}}
 \newcommand\parens[1]{\left( #1 \right)}
-\newcommand\substitute[3]{#1 \left[ #2 \mapsto #3 \right]}
+\newcommand\substitute[3]{#1 \left[ #3 / #2 \right]}
 \makeatletter
-\renewcommand{\boxed}[1]{\text{\fboxsep=.2em\fbox{\m@th$\displaystyle#1$}}}
+\renewcommand{\boxed}[1]{\text{\kern 0.1em\fboxsep=.2em\fbox{\m@th$\displaystyle#1$}\kern 0.1em}}
 \makeatother
 
 % Terms
@@ -106,10 +106,11 @@
 
 % Judgments
 \newcommand\subrowSym{\sqsubseteq}
-\newcommand\subtypeSym{\leq}
 \newcommand\subrow[2]{#1 \subrowSym #2}
+\newcommand\subtypeSym{\leq}
 \newcommand\subtype[2]{#1 \subtypeSym #2}
 \newcommand\hasType[5]{#1; #2 \vdash \anno{#3}{\tEmbellished{#4}{#5}}}
+\newcommand\infer[1]{\boxed{#1}}
 \newcommand\initWellFormed[2]{#1; #2 \; \text{initial}}
 
 %%%%%%%%%%%%%%%%%%%%%
@@ -147,12 +148,12 @@
         \begin{mdframed}[backgroundcolor=none]
           \begin{center}
             \begin{tabular}{l l l}
-              $\term \Coloneqq $ & & terms: \\
+              $\term \Coloneqq$ & & terms: \\
               & $\eUnit$ & unit \\
               & $\eVar$ & variable \\
               & $\eAbs{\eVar}{\term}$ & abstraction \\
               & $\eApp{\term}{\term}$ & application \\
-              & $\eHandle{\effect}{\overline{\effect_i}}{\term}{\term}$ & effect definition \\
+              & $\eHandle{\effect}{\row}{\term}{\term}$ & effect definition \\
               & $\eAnno{\term}{\type}{\row}$ & annotation \\
               \\
               $\type \Coloneqq$ & & types: \\
@@ -224,7 +225,7 @@
             \TrinaryInfC{$\subtype{\tArrow{\type_1}{\type_2}{\row_1}}{\tArrow{\type_3}{\type_4}{\row_2}}$}
           \end{prooftree}
 
-          \caption{Subtyping rules}\label{fig:subtyping_rules}
+          \caption{Subtyping}\label{fig:subtyping_rules}
         \end{mdframed}
       \end{figure}
 
@@ -233,50 +234,122 @@
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]
           \begin{center}
-            \framebox{$\hasType{\context}{\effectMap}{\term}{\type}{\row}$}
+            \framebox{
+              $\hasType{\context}{\effectMap}{\term}{\type}{\row}$
+              \qquad
+              $\hasType{\context}{\effectMap}{\term}{\infer{\type}}{\row}$
+              \qquad
+              $\hasType{\context}{\effectMap}{\term}{\type}{\infer{\row}}$
+              \qquad
+              $\hasType{\context}{\effectMap}{\term}{\infer{\type}}{\infer{\row}}$
+            }
           \end{center}
 
           \medskip
 
-          \begin{prooftree}
-              \AxiomC{}
-            \RightLabel{(\textsc{T-Unit})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eUnit}{\tUnit}{\rEmpty}$}
-          \end{prooftree}
+          \begin{minipage}[t]{0.49\textwidth}
+
+            \begin{prooftree}
+                \AxiomC{}
+              \RightLabel{(\textsc{T-Unit})}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eUnit}{\infer{\tUnit}}{\infer{\rEmpty}}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\type}{\row}$}
+              \RightLabel{(\textsc{T-Var})}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\infer{\type}}{\infer{\row}}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{$\hasType{\cExtend{\context}{\eVar}{\type_1}{\rEmpty}}{\effectMap}{\term}{\type_2}{\row_2}$}
+              \RightLabel{(\textsc{T-Abs})}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\parens{\eAbs{\eVar}{\term}}}{\parens{\tArrow{\type_1}{\type_2}{\row_2}}}{\infer{\rEmpty}}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{\Shortstack[c]{
+                  {$\hasType{\context}{\effectMap}{\term_2}{\infer{\parens{\tArrow{\type_1}{\type_2}{\row_2}}}}{\infer{\row_3}}$}
+                  {$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\infer{\row_1}}$}
+                }}
+              \RightLabel{(\textsc{T-App})}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_2}{\term_1}}{\infer{\type_2}}{\infer{\rUnion{\rUnion{\row_1}{\row_2}}{\row_3}}}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\type}{\row}$}
+              \RightLabel{(\textsc{T-Anno})}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\parens{\eAnno{\term}{\type}{\row}}}{\infer{\type}}{\infer{\row}}$}
+            \end{prooftree}
+
+          \end{minipage}
+          \begin{minipage}[t]{0.49\textwidth}
+
+            \begin{prooftree}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\infer{\type}}{\infer{\row_1}}$}
+                \AxiomC{$\subrow{\row_1}{\row_2}$}
+              \RightLabel{(\textsc{T-Sub1})}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\infer{\type}}{\row_2}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\infer{\type_1}}{\infer{\row}}$}
+                \AxiomC{$\subtype{\type_1}{\type_2}$}
+              \RightLabel{(\textsc{T-Sub2})}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\type_2}{\infer{\row}}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\infer{\type_1}}{\row}$}
+                \AxiomC{$\subtype{\type_1}{\type_2}$}
+              \RightLabel{(\textsc{T-Sub3})}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\type_2}{\row}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\type}{\infer{\row_1}}$}
+                \AxiomC{$\subrow{\row_1}{\row_2}$}
+              \RightLabel{(\textsc{T-Sub4})}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_2}$}
+            \end{prooftree}
+
+            \begin{prooftree}
+                \AxiomC{\Shortstack[c]{
+                  {$\hasType{\context}{\effectMap}{\term}{\infer{\type_1}}{\infer{\row_1}}$}
+                  {$\subtype{\type_1}{\type_2}$}
+                  {$\subrow{\row_1}{\row_2}$}
+                }}
+              \RightLabel{(\textsc{T-Sub5})}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\term}{\type_2}{\row_2}$}
+            \end{prooftree}
+
+          \end{minipage}
 
           \begin{prooftree}
-              \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\type}{\row}$}
-            \RightLabel{(\textsc{T-Variable})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\type}{\row}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\cExtend{\context}{\eVar}{\type_1}{\rEmpty}}{\effectMap}{\term}{\type_2}{\row_2}$}
-            \RightLabel{(\textsc{T-Abstraction})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\parens{\eAbs{\anno{\eVar}{\type_1}}{\term}}}{\parens{\tArrow{\type_1}{\type_2}{\row_2}}}{\rEmpty}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\row_1}$}
-              \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\parens{\tArrow{\type_3}{\type_2}{\row_2}}}{\row_3}$}
-              \AxiomC{$\subtype{\type_1}{\type_3}$}
-            \RightLabel{(\textsc{T-Application})}
-            \TrinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_2}{\term_1}}{\type_2}{\rUnion{\rUnion{\row_1}{\row_2}}{\row_3}}$}
+              \AxiomC{\Shortstack[c]{
+                {$\hasType{\context}{\effectMap}{\term_2}{\infer{\type_2}}{\infer{\row_2}}$}
+                {$\hasType{\context}{\effectMap}{\apply{\effectMap}{\effect}}{\infer{\type_3}}{\infer{\row_3}}$}
+                {$\type_1 = \substitute{\type_3}{\rSingleton{\effect}}{\row_4}$}
+                {$\row_1 = \substitute{\row_3}{\rSingleton{\effect}}{\row_4}$}
+                {$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\row_1}$}
+              }}
+            \RightLabel{(\textsc{T-Handle1})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\effect}{\row_4}{\term_1}{\term_2}}{\infer{\type_2}}{\infer{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\row_4}}}$}
           \end{prooftree}
 
           \begin{prooftree}
               \AxiomC{\Shortstack[c]{
+                {$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\infer{\row_2}}$}
+                {$\hasType{\context}{\effectMap}{\apply{\effectMap}{\effect}}{\infer{\type_3}}{\infer{\row_3}}$}
+                {$\type_1 = \substitute{\type_3}{\rSingleton{\effect}}{\row_4}$}
+                {$\row_1 = \substitute{\row_3}{\rSingleton{\effect}}{\row_4}$}
                 {$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\row_1}$}
-                {$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
-                {$\hasType{\context}{\effectMap}{\apply{\effectMap}{\effect}}{\type_3}{\row_3}$}
-                {$\subtype{\type_1}{\substitute{\type_3}{\rSingleton{\effect}}{\bigcup_i \effect_i}}$}
-                {$\subrow{\row_1}{\substitute{\row_3}{\rSingleton{\effect}}{\bigcup_i \effect_i}}$}
               }}
-            \RightLabel{(\textsc{T-Handle})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\effect}{\overline{\effect_i}}{\term_1}{\term_2}}{\type_2}{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\effect_i}}$}
+            \RightLabel{(\textsc{T-Handle2})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\effect}{\row_4}{\term_1}{\term_2}}{\type_2}{\infer{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\row_4}}}$}
           \end{prooftree}
 
-          \caption{Typing rules}\label{fig:typing_rules}
+          \caption{Type inference}\label{fig:typing_rules}
         \end{mdframed}
       \end{figure}
 


### PR DESCRIPTION
Document the inference algorithm in the paper. The algorithm didn't fit cleanly on one page, so I split it into two columns.

When writing up the algorithm, I also discovered and fixed three problems:

1. In the Haskell implementation for `T-Handle`, we were in inference mode for the type of the user-supplied implementation of the operation. This was not wrong per se, but it was undesirable because we were unable to take advantage of information we already know (the expected type of the operation). The reason we were in inference mode and not checking mode is because we wanted to allow for subtyping; so the algorithm was a) infer the type, b) check that it is a subtype of the expected type. But, luckily, the subsumption rules already handle subtyping (in this case, `T-Subsumption 3-5`). So we can actually use checking mode here and let the subsumption rule handle subtyping for us. What a pleasant surprise!
2. Also for `T-Handle`, I realized that this rule works in two modes: `inferTypeAndRow` and `checkTypeInferRow` (and neither subsumes the other). So now we have both (the Haskell and LaTeX have both been updated).
3. In `T-Abstraction`, the abstraction syntax had a type annotation on the variable (which doesn't match the definition of the syntax in the paper). I updated it to not have a type annotation on the argument (as most bidirectional typechecking systems do not have this).

Also: thanks to @esdrw's brilliant suggestion to reverse the substitutions in `T-Handle`, I think we can now use an ordinary effect row instead of a list of effects for the "using" construct (we should think of a good name for this). I updated the Coq, Haskell, and LaTeX to reflect this.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-inference.pdf) is a link to the PDF generated from this PR.
