### PR TITLE
Simplify the context well-formedness figure and make some small syntax improvements

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -111,7 +111,7 @@
 \newcommand\subtype[2]{#1 \subtypeSym #2}
 \newcommand\hasType[5]{#1; #2 \vdash \anno{#3}{\tEmbellished{#4}{#5}}}
 \newcommand\infer[1]{\boxed{#1}}
-\newcommand\initWellFormed[2]{#1; #2 \; \text{initial}}
+\newcommand\wellFormed[2]{#1; #2 \; \text{well-formed}}
 
 %%%%%%%%%%%%%%%%%%%%%
 % The specification %
@@ -256,7 +256,7 @@
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\type}{\row}$}
+                \AxiomC{$\tEmbellished{\type}{\row} = \apply{\context}{\eVar}$}
               \RightLabel{(\textsc{T-Var})}
               \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\infer{\type}}{\infer{\row}}$}
             \end{prooftree}
@@ -269,7 +269,7 @@
 
             \begin{prooftree}
                 \AxiomC{\Shortstack[c]{
-                  {$\hasType{\context}{\effectMap}{\term_2}{\infer{\parens{\tArrow{\type_1}{\type_2}{\row_2}}}}{\infer{\row_3}}$}
+                  {$\hasType{\context}{\effectMap}{\term_2}{\infer{\parens{\tArrow{\type_1}{\type_2}{\row_3}}}}{\infer{\row_2}}$}
                   {$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\infer{\row_1}}$}
                 }}
               \RightLabel{(\textsc{T-App})}
@@ -327,11 +327,11 @@
 
           \begin{prooftree}
               \AxiomC{\Shortstack[c]{
-                {$\hasType{\context}{\effectMap}{\term_2}{\infer{\type_2}}{\infer{\row_2}}$}
-                {$\hasType{\context}{\effectMap}{\apply{\effectMap}{\effect}}{\infer{\type_3}}{\infer{\row_3}}$}
+                {$\tEmbellished{\type_3}{\row_3} = \apply{\context}{\apply{\effectMap}{\effect}}$}
                 {$\type_1 = \substitute{\type_3}{\rSingleton{\effect}}{\row_4}$}
                 {$\row_1 = \substitute{\row_3}{\rSingleton{\effect}}{\row_4}$}
                 {$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\row_1}$}
+                {$\hasType{\context}{\effectMap}{\term_2}{\infer{\type_2}}{\infer{\row_2}}$}
               }}
             \RightLabel{(\textsc{T-Handle1})}
             \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\effect}{\row_4}{\term_1}{\term_2}}{\infer{\type_2}}{\infer{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\row_4}}}$}
@@ -339,11 +339,11 @@
 
           \begin{prooftree}
               \AxiomC{\Shortstack[c]{
-                {$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\infer{\row_2}}$}
-                {$\hasType{\context}{\effectMap}{\apply{\effectMap}{\effect}}{\infer{\type_3}}{\infer{\row_3}}$}
+                {$\tEmbellished{\type_3}{\row_3} = \apply{\context}{\apply{\effectMap}{\effect}}$}
                 {$\type_1 = \substitute{\type_3}{\rSingleton{\effect}}{\row_4}$}
                 {$\row_1 = \substitute{\row_3}{\rSingleton{\effect}}{\row_4}$}
                 {$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\row_1}$}
+                {$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\infer{\row_2}}$}
               }}
             \RightLabel{(\textsc{T-Handle2})}
             \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\effect}{\row_4}{\term_1}{\term_2}}{\type_2}{\infer{\rUnion{\parens{\rDiff{\row_2}{\rSingleton{\effect}}}}{\row_4}}}$}
@@ -356,38 +356,33 @@
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]
           \begin{center}
-            \framebox{$\initWellFormed{\context}{\effectMap}$}
+            \framebox{$\wellFormed{\context}{\effectMap}$}
           \end{center}
 
           \medskip
 
           \begin{prooftree}
               \AxiomC{}
-            \RightLabel{(\textsc{INIT-Empty})}
-            \UnaryInfC{$\initWellFormed{\cEmpty}{\emEmpty}$}
+            \RightLabel{(\textsc{WF-Empty})}
+            \UnaryInfC{$\wellFormed{\context}{\emEmpty}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\initWellFormed{\context}{\effectMap}$}
+              \AxiomC{$\wellFormed{\context}{\effectMap}$}
+              \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\type}{\row}$}
               \AxiomC{$\subrow{\rSingleton{\effect}}{\row}$}
-            \RightLabel{(\textsc{INIT-Unit})}
-            \BinaryInfC{$\initWellFormed{\cExtend{\context}{\eVar}{\tUnit}{\row}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
+            \RightLabel{(\textsc{WF-Effect1})}
+            \TrinaryInfC{$\wellFormed{\context}{\emExtend{\effectMap}{\effect}{\eVar}}$}
           \end{prooftree}
 
           \begin{prooftree}
-              \AxiomC{$\initWellFormed{\context}{\effectMap}$}
-              \AxiomC{$\subrow{\rSingleton{\effect}}{\row_2}$}
-            \RightLabel{(\textsc{INIT-Arrow1})}
-            \BinaryInfC{$\initWellFormed{\cExtend{\context}{\eVar}{\parens{\tArrow{\type_1}{\type_2}{\row_1}}}{\row_2}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
+              \AxiomC{$\wellFormed{\cExtend{\context}{\eVar}{\type_2}{\row_2}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
+              \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\parens{\tArrow{\type_1}{\type_2}{\row_2}}}{\row_1}$}
+            \RightLabel{(\textsc{WF-Effect2})}
+            \BinaryInfC{$\wellFormed{\context}{\emExtend{\effectMap}{\effect}{\eVar}}$}
           \end{prooftree}
 
-          \begin{prooftree}
-              \AxiomC{$\initWellFormed{\cExtend{\context}{\eVar}{\type_2}{\row_1}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-            \RightLabel{(\textsc{INIT-Arrow2})}
-            \UnaryInfC{$\initWellFormed{\cExtend{\context}{\eVar}{\parens{\tArrow{\type_1}{\type_2}{\row_1}}}{\row_2}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-          \end{prooftree}
-
-          \caption{Initial type and effect context well-formedness}\label{fig:context_well_formedness}
+          \caption{Type and effect context well-formedness}\label{fig:context_well_formedness}
         \end{mdframed}
       \end{figure}
 


### PR DESCRIPTION
Simplify the context well-formedness figure and make some small syntax improvements.

Note: the well-formedness figure simplification was @esdrw's idea.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-well-formedness.pdf) is a link to the PDF generated from this PR.
