### PR TITLE
Remove the type and effect row from emExtend in the Coq script

### DIFF
--- a/formalization/syntax.v
+++ b/formalization/syntax.v
@@ -54,5 +54,5 @@ Module Syntax (IdentifiersInstance : Identifiers).
 
   with effectMap : Type :=
   | emEmpty : effectMap
-  | emExtend : effectMap -> effectId -> termId -> type -> row -> effectMap.
+  | emExtend : effectMap -> effectId -> termId -> effectMap.
 End Syntax.


### PR DESCRIPTION
Remove the type and effect row from emExtend in the Coq script.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-coq-effect-map.pdf) is a link to the PDF generated from this PR.
