### PR TITLE
Set up the Coq project properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .paper-build
-formalization/*.glob
-formalization/*.vo
-formalization/*.vo.aux
+formalization/**/*.glob
+formalization/**/*.v.d
+formalization/**/*.vo
+formalization/**/*.vo.aux
 implementation/.stack-work/*
 main.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-override COQ_SOURCES := $(shell find formalization/*.v -type f) \
-
 # Phony targets
 
 .PHONY: \
@@ -32,7 +30,13 @@ lint:
 	      \) -print \
 	  )
 
-formalization: $(patsubst %.v,%.vo,$(COQ_SOURCES))
+formalization:
+	rm -f CoqMakefile _CoqProject
+	echo '-R formalization Main' > _CoqProject
+	find formalization -type f -name '*.v' >> _CoqProject
+	coq_makefile -f _CoqProject -o CoqMakefile
+	make -f CoqMakefile
+	rm -f CoqMakefile _CoqProject
 
 implementation:
 	cd implementation && \
@@ -45,11 +49,13 @@ clean-paper:
 	rm -rf .paper-build main.pdf
 
 clean-formalization:
-	rm -rf \
-	  formalization/*.glob \
-	  formalization/*.vo \
-	  formalization/.*.vo.aux \
-	  .paper-build
+	rm -f _CoqProject CoqMakefile \
+	  $(shell find . -type f \( \
+	    -name '*.glob' -o \
+	    -name '*.v.d' -o \
+	    -name '*.vo' -o \
+	    -name '*.vo.aux' \
+	  \) -print)
 
 clean-implementation:
 	rm -rf implementation/.stack-work
@@ -85,8 +91,3 @@ main.pdf: paper/main.tex
 	    paper/main.tex; \
 	done
 	mv .paper-build/main.pdf .
-
-# The formalization
-
-formalization/syntax.vo: formalization/syntax.v
-	COQPATH="$$(pwd)/formalization" coqc formalization/syntax.v


### PR DESCRIPTION
Set up the Coq project properly. Now, if you want to add a new Coq file, all you have to do is create the file. The `Makefile` automatically:

1. Finds all the Coq files
2. Determines all their dependencies
3. Builds them incrementally (only the ones that need to be rebuilt)

I also tested this to make sure it supports Coq files importing other Coq files from nested subdirectories.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-coq-project.pdf) is a link to the PDF generated from this PR.
