### PR TITLE
Add a _CoqProject file

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,2 @@
+# This file is used by CoqIDE.
+-R coq Main


### PR DESCRIPTION
Add a `_CoqProject` file.

In https://github.com/stepchowfun/delimited-effects/pull/260, I updated the `Makefile` to support automatic discovery of Coq files. Even though the build system supported subdirectories, it seemed CoqIDE didn't.

After hours of debugging and Googling, I finally found a solution: this `_CoqProject` file. It is not a full `_CoqProject` since it does not explicitly enumerate the `.v` Coq files (by design, so we don't have to maintain it). This is just enough to get CoqIDE to set up its paths correctly such that nested subdirectories work. I'm using this successfully in https://github.com/stepchowfun/coq-fun which has some non-flat directory structure.

Note that our `make` system automatically generates (and subsequently deletes) a _different_ `_CoqProject` file (actually called `_CoqProjectFull`) with the full list of `.v` files so the compiler knows what to compile. That means `make` and CoqIDE deal with two distinct `_CoqProject` files.

Basically, after this PR is merged, everything should "just work" no matter how we want to organize the Coq files in the repo.

I really dislike the Coq tooling and (lack of) documentation, but at least we won't have to think about it anymore.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-coqproject.pdf) is a link to the PDF generated from this PR.
