### PR TITLE
Fix the _CoqProject setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ lint:
 	  )
 
 formalization:
-	rm -f CoqMakefile _CoqProject
-	echo '-R formalization Main' > _CoqProject
-	find formalization -type f -name '*.v' >> _CoqProject
-	coq_makefile -f _CoqProject -o CoqMakefile
+	rm -f CoqMakefile _CoqProjectFull
+	echo '-R formalization Main' > _CoqProjectFull
+	find formalization -type f -name '*.v' >> _CoqProjectFull
+	coq_makefile -f _CoqProjectFull -o CoqMakefile
 	make -f CoqMakefile
-	rm -f CoqMakefile _CoqProject
+	rm -f CoqMakefile _CoqProjectFull
 
 implementation:
 	cd implementation && \
@@ -49,7 +49,7 @@ clean-paper:
 	rm -rf .paper-build main.pdf
 
 clean-formalization:
-	rm -f _CoqProject CoqMakefile \
+	rm -f _CoqProjectFull CoqMakefile \
 	  $(shell find . -type f \( \
 	    -name '*.glob' -o \
 	    -name '*.v.d' -o \

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,2 +1,2 @@
 # This file is used by CoqIDE.
--R coq Main
+-R formalization Main


### PR DESCRIPTION
Fix the `_CoqProject` setup. I just blindly copied the file from my `coq-fun` repo, but I forgot that the Coq directory is called `formalization` instead of `coq`. Doh. I actually tested it this time in CoqIDE.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-coqproject.pdf) is a link to the PDF generated from this PR.
