### PR TITLE
Update the Makefile to clean up some temporary files even when the build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,14 @@ lint:
 	  )
 
 formalization:
-	rm -f CoqMakefile _CoqProjectFull
+	rm -f Makefile.coq _CoqProjectFull
 	echo '-R formalization Main' > _CoqProjectFull
 	find formalization -type f -name '*.v' >> _CoqProjectFull
-	coq_makefile -f _CoqProjectFull -o CoqMakefile
-	make -f CoqMakefile
-	rm -f CoqMakefile _CoqProjectFull
+	coq_makefile -f _CoqProjectFull -o Makefile.coq || \
+	  (rm -f Makefile.coq _CoqProjectFull; exit 1)
+	make -f Makefile.coq || \
+	  (rm -f Makefile.coq _CoqProjectFull; exit 1)
+	rm -f Makefile.coq _CoqProjectFull
 
 implementation:
 	cd implementation && \
@@ -49,7 +51,7 @@ clean-paper:
 	rm -rf .paper-build main.pdf
 
 clean-formalization:
-	rm -f _CoqProjectFull CoqMakefile \
+	rm -f _CoqProjectFull Makefile.coq \
 	  $(shell find . -type f \( \
 	    -name '*.glob' -o \
 	    -name '*.v.d' -o \


### PR DESCRIPTION
1. Rename `CoqMakefile` to `Makefile.coq` to be consistent with Adam Chlipala/CPDT (why not ~)
2. Update the Makefile to clean up some temporary files even when the build fails.

Regarding (2), the files in question are `Makefile.coq` and `_CoqProjectFull`. These are normally created and deleted automatically when building the formalization. But when the build fails, they are left behind. We could add them to the `.gitignore` or just make sure to always clean them up even when the build fails. This PR implements the latter.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-make-fail.pdf) is a link to the PDF generated from this PR.
