### PR TITLE
Add a Boolean primitive type to the Coq formalization

### DIFF
--- a/formalization/Syntax.v
+++ b/formalization/Syntax.v
@@ -17,7 +17,8 @@ Module Syntax (IdentifiersInstance : Identifiers).
   (* Terms *)
 
   Inductive term : Type :=
-  | eUnit : term
+  | eTrue : term
+  | eFalse : term
   | eVar : termId -> term
   | eAbs : termId -> term -> term
   | eApp : term -> term -> term
@@ -27,7 +28,7 @@ Module Syntax (IdentifiersInstance : Identifiers).
   (* Proper types *)
 
   with type : Type :=
-  | tUnit : type
+  | tBool : type
   | tArrow : type -> row -> type -> row -> type
 
   (* Rows *)


### PR DESCRIPTION
Add a Boolean primitive type to the Coq formalization. @esdrw is doing the same for the Haskell implementation in https://github.com/stepchowfun/delimited-effects/pull/267.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-bool.pdf) is a link to the PDF generated from this PR.
