### PR TITLE
Move the implementation tests to a separate make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # Phony targets
 
 .PHONY: \
-  all \
+  all test \
   paper lint formalization implementation \
   clean clean-paper clean-formalization clean-implementation \
   docker-deps docker-build
 
 all: paper lint formalization implementation
+
+test: implementation-test
 
 paper: main.pdf
 
@@ -42,7 +44,10 @@ formalization:
 
 implementation:
 	cd implementation && \
-	  stack build --pedantic --install-ghc --allow-different-user && \
+	  stack build --pedantic --install-ghc --allow-different-user
+
+implementation-test: implementation
+	cd implementation && \
 	  stack test --pedantic --install-ghc --allow-different-user
 
 clean: clean-paper clean-formalization clean-implementation
@@ -85,6 +90,7 @@ docker-build:
 	      su user -c " \
 	        make clean && \
 		make && \
+		make test && \
 		./scripts/travis-deploy.sh \
 	      " \
 	    ' \


### PR DESCRIPTION
Move the implementation tests to a separate make target. Now, just running `make` does not run the tests (which makes it really fast if there is nothing to build). You can run `make test` to run the tests. The CI system is configured to do both, of course.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-test-target.pdf) is a link to the PDF generated from this PR.
