### PR TITLE
Add automatic formatting for Haskell code

### DIFF
--- a/implementation/Setup.hs
+++ b/implementation/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/implementation/app/Main.hs
+++ b/implementation/app/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import Lexer as Lexer
 import Lib ()
@@ -14,5 +16,7 @@ main = do
       let tokens = Lexer.alexScanTokens program
       print tokens
       print (Parser.parse tokens)
-    _ -> print "Provide the name of a file containing \
+    _ ->
+      print
+        "Provide the name of a file containing \
                \ a program to execute. For example, `implementation-exe test`."

--- a/implementation/src/Error.hs
+++ b/implementation/src/Error.hs
@@ -2,7 +2,8 @@ module Error
   ( Partial
   , abort
   , assert
-  , maybeToPartial ) where
+  , maybeToPartial
+  ) where
 
 type Partial a = Either String a
 
@@ -10,7 +11,10 @@ abort :: String -> Partial a
 abort s = Left s
 
 assert :: Bool -> String -> Partial ()
-assert b s = if b then return () else abort s
+assert b s =
+  if b
+    then return ()
+    else abort s
 
 maybeToPartial :: Maybe a -> String -> Partial a
 maybeToPartial (Just x) _ = return x

--- a/implementation/src/Inference.hs
+++ b/implementation/src/Inference.hs
@@ -1,140 +1,137 @@
-module Inference (check, infer) where
+module Inference
+  ( check
+  , infer
+  ) where
 
+import Data.Maybe as Maybe
 import Error (Partial, abort, assert, maybeToPartial)
 import Subrow (subrow)
 import Syntax
-  ( Context(..)
-  , EffectMap(..)
-  , HoistedSet(..)
-  , Row(..)
-  , Term(..)
-  , Type(..)
-  , contextLookupKind
-  , contextLookupType
-  , eff
-  , effectMapLookup
-  , ftv
-  , fv
-  , substituteEffectInRow
-  , substituteEffectInType
-  , substituteTypeInType )
-import Data.Maybe as Maybe
+       (Context(..), EffectMap(..), HoistedSet(..), Row(..), Term(..),
+        Type(..), contextLookupKind, contextLookupType, eff,
+        effectMapLookup, ftv, fv, substituteEffectInRow,
+        substituteEffectInType, substituteTypeInType)
 
 -- Check the type and row
-
-check :: Context
-      -> EffectMap
-      -> Term
-      -> Type
-      -> Row
-      -> Partial HoistedSet
-check c em (EAbs x e) (TArrow t2 r2 t1 r1) r3 =
-  do h1 <- check (CTExtend c x t2 r2) em e t1 r1
-     assert
-       (elem x (fv h1))
-       ("Effects '" ++ show (eff h1) ++ "' cannot be hoisted outside" ++
-         " the scope of variable '" ++ show x ++ ".")
-     let h2 =
-           if subrow (eff h1) r3
-           then HEmpty
-           else h1
-     return h2
-check _ _ (EAbs _ _) _ _ = abort
-  "Checking for arrow types only succeeds on term abstractions."
-check c em (ETAbs a1 e) (TForall a2 t r1) r2 =
-    do assert
-         (a1 == a2)
-         ("Checking for universal types only succeeds when the type" ++
-           " variables match in the term and type.")
-       assert
-         (Maybe.isJust $ contextLookupKind c a1)
-         ("Type variables in a scope must be unique.")
-       h1 <- check (CKExtend c a1) em e t r1
-       assert
-         (elem a1 (ftv h1))
-         ("Effects '" ++ show (eff h1) ++ "' cannot be hoisted outside" ++
-           " the scope of variable '" ++ show a1 ++ ".")
-       let h2 =
-             if subrow (eff h1) r2
-             then HEmpty
-             else h1
-       return h2
-check _ _ (ETAbs _ _) _ _ = abort
-  "Checking for universal types only succeeds on type abstractions."
-check c em (EHandle z e1 e2) t1 r1 =
-  do (t2, r2) <- maybeToPartial (
-         do x <- effectMapLookup em z
-            contextLookupType c x
-       ) ("Failed to look up the type of operation '" ++ show z ++ "'.")
-     let t3 = substituteEffectInType z r1 t2
-         r3 = substituteEffectInRow z r1 r2
-     h1 <- check c em e1 t3 r3
-     h2 <- check c em e2 t1 (RUnion r1 (RSingleton z))
-     let h3 = if subrow (eff h1) r1 then HEmpty else h1
-     return (HUnion h2 h3)
-check c em e t1 r =
-  do (t2, h) <- infer c em e r
-     assert (t1 == t2) ("Subsumption cannot be applied because the types '" ++
-       show t1 ++ "' and '" ++ show t2 ++ "' are not equal")
-     return h
+check :: Context -> EffectMap -> Term -> Type -> Row -> Partial HoistedSet
+check c em (EAbs x e) (TArrow t2 r2 t1 r1) r3 = do
+  h1 <- check (CTExtend c x t2 r2) em e t1 r1
+  assert
+    (elem x (fv h1))
+    ("Effects '" ++
+     show (eff h1) ++
+     "' cannot be hoisted outside" ++
+     " the scope of variable '" ++ show x ++ ".")
+  let h2 =
+        if subrow (eff h1) r3
+          then HEmpty
+          else h1
+  return h2
+check _ _ (EAbs _ _) _ _ =
+  abort "Checking for arrow types only succeeds on term abstractions."
+check c em (ETAbs a1 e) (TForall a2 t r1) r2 = do
+  assert
+    (a1 == a2)
+    ("Checking for universal types only succeeds when the type" ++
+     " variables match in the term and type.")
+  assert
+    (Maybe.isJust $ contextLookupKind c a1)
+    ("Type variables in a scope must be unique.")
+  h1 <- check (CKExtend c a1) em e t r1
+  assert
+    (elem a1 (ftv h1))
+    ("Effects '" ++
+     show (eff h1) ++
+     "' cannot be hoisted outside" ++
+     " the scope of variable '" ++ show a1 ++ ".")
+  let h2 =
+        if subrow (eff h1) r2
+          then HEmpty
+          else h1
+  return h2
+check _ _ (ETAbs _ _) _ _ =
+  abort "Checking for universal types only succeeds on type abstractions."
+check c em (EHandle z e1 e2) t1 r1 = do
+  (t2, r2) <-
+    maybeToPartial
+      (do x <- effectMapLookup em z
+          contextLookupType c x)
+      ("Failed to look up the type of operation '" ++ show z ++ "'.")
+  let t3 = substituteEffectInType z r1 t2
+      r3 = substituteEffectInRow z r1 r2
+  h1 <- check c em e1 t3 r3
+  h2 <- check c em e2 t1 (RUnion r1 (RSingleton z))
+  let h3 =
+        if subrow (eff h1) r1
+          then HEmpty
+          else h1
+  return (HUnion h2 h3)
+check c em e t1 r = do
+  (t2, h) <- infer c em e r
+  assert
+    (t1 == t2)
+    ("Subsumption cannot be applied because the types '" ++
+     show t1 ++ "' and '" ++ show t2 ++ "' are not equal")
+  return h
 
 -- Infer the type and check the row
-
-infer :: Context
-      -> EffectMap
-      -> Term
-      -> Row
-      -> Partial (Type, HoistedSet)
-infer c _ (EVar x) r1 =
-  do (t, r2) <- maybeToPartial (contextLookupType c x)
-       ("Variable '" ++ show x ++ "' is not in the type context.")
-     let h =
-           if subrow r2 r1
-           then HEmpty
-           else HSingleton (EVar x) t r2
-     return (t, h)
-infer _ _ (EAbs _ _) _ = abort
-  "The type of a term abstraction cannot be synthesized."
-infer c em (EApp e1 e2) r3 =
-  do (t3, h1) <- infer c em e1 r3
-     case t3 of
-       TArrow t2 r2 t1 r1 ->
-         do h2 <- check c em e2 t2 r2
-            let h3 =
-                  case (subrow r1 r3, subrow (eff h2) r3) of
-                    (True, True) -> h1
-                    (True, False) -> HUnion h1 h2
-                    (False, _) ->
-                      HSingleton
-                        (EApp e1 e2)
-                        t1
-                        (RUnion (RUnion (RUnion r1 r3) (eff h1)) (eff h2))
-            return (t1, h3)
-       _ -> abort "The type of a term applicand must be an arrow."
-infer _ _ (ETAbs _ _) _ = abort
-  "The type of a type abstraction cannot be synthesized."
-infer c em (ETApp e t2) r2 =
-  do (t3, h1) <- infer c em e r2
-     case t3 of
-       TForall a t1 r1 ->
-         let t4 = substituteTypeInType a t2 t1
-             h2 =
-               if (subrow r1 r2)
-               then h1
-               else HSingleton (ETApp e t2) t4 (RUnion (RUnion r1 r2) (eff h1))
-         in return (t4, h2)
-       _ -> abort "The type of a type applicand must be a forall."
-infer c em (EHandle z e1 e2) r1 =
-  do (t2, r2) <- maybeToPartial (
-         do x <- effectMapLookup em z
-            contextLookupType c x
-       ) ("Failed to look up the type of operation '" ++ show z ++ "'.")
-     let t3 = substituteEffectInType z r1 t2
-         r3 = substituteEffectInRow z r1 r2
-     h1 <- check c em e1 t3 r3
-     (t1, h2) <- infer c em e2 (RUnion r1 (RSingleton z))
-     let h3 = if subrow (eff h1) r1 then HEmpty else h1
-     return (t1, HUnion h2 h3)
-infer c em (EAnno e t) r =
-  do h <- check c em e t r
-     return (t, h)
+infer :: Context -> EffectMap -> Term -> Row -> Partial (Type, HoistedSet)
+infer c _ (EVar x) r1 = do
+  (t, r2) <-
+    maybeToPartial
+      (contextLookupType c x)
+      ("Variable '" ++ show x ++ "' is not in the type context.")
+  let h =
+        if subrow r2 r1
+          then HEmpty
+          else HSingleton (EVar x) t r2
+  return (t, h)
+infer _ _ (EAbs _ _) _ =
+  abort "The type of a term abstraction cannot be synthesized."
+infer c em (EApp e1 e2) r3 = do
+  (t3, h1) <- infer c em e1 r3
+  case t3 of
+    TArrow t2 r2 t1 r1 -> do
+      h2 <- check c em e2 t2 r2
+      let h3 =
+            case (subrow r1 r3, subrow (eff h2) r3) of
+              (True, True) -> h1
+              (True, False) -> HUnion h1 h2
+              (False, _) ->
+                HSingleton
+                  (EApp e1 e2)
+                  t1
+                  (RUnion (RUnion (RUnion r1 r3) (eff h1)) (eff h2))
+      return (t1, h3)
+    _ -> abort "The type of a term applicand must be an arrow."
+infer _ _ (ETAbs _ _) _ =
+  abort "The type of a type abstraction cannot be synthesized."
+infer c em (ETApp e t2) r2 = do
+  (t3, h1) <- infer c em e r2
+  case t3 of
+    TForall a t1 r1 ->
+      let t4 = substituteTypeInType a t2 t1
+          h2 =
+            if (subrow r1 r2)
+              then h1
+              else HSingleton (ETApp e t2) t4 (RUnion (RUnion r1 r2) (eff h1))
+      in return (t4, h2)
+    _ -> abort "The type of a type applicand must be a forall."
+infer c em (EHandle z e1 e2) r1 = do
+  (t2, r2) <-
+    maybeToPartial
+      (do x <- effectMapLookup em z
+          contextLookupType c x)
+      ("Failed to look up the type of operation '" ++ show z ++ "'.")
+  let t3 = substituteEffectInType z r1 t2
+      r3 = substituteEffectInRow z r1 r2
+  h1 <- check c em e1 t3 r3
+  (t1, h2) <- infer c em e2 (RUnion r1 (RSingleton z))
+  let h3 =
+        if subrow (eff h1) r1
+          then HEmpty
+          else h1
+  return (t1, HUnion h2 h3)
+infer c em (EAnno e t) r = do
+  h <- check c em e t r
+  return (t, h)

--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -22,30 +22,15 @@ module Lib
   , subrow
   , substituteEffectInRow
   , substituteEffectInType
-  , substituteTypeInType ) where
+  , substituteTypeInType
+  ) where
 
-import Error
-  ( Partial
-  , abort
-  , assert
-  , maybeToPartial )
+import Error (Partial, abort, assert, maybeToPartial)
 import Inference (check, infer)
 import Subrow (subrow)
 import Syntax
-  ( Context(..)
-  , EffectMap(..)
-  , HoistedSet(..)
-  , Row(..)
-  , Term(..)
-  , Type(..)
-  , contextLookupKind
-  , contextLookupType
-  , eff
-  , effectMapLookup
-  , effects
-  , ftv
-  , fv
-  , rowContains
-  , substituteEffectInRow
-  , substituteEffectInType
-  , substituteTypeInType )
+       (Context(..), EffectMap(..), HoistedSet(..), Row(..), Term(..),
+        Type(..), contextLookupKind, contextLookupType, eff,
+        effectMapLookup, effects, ftv, fv, rowContains,
+        substituteEffectInRow, substituteEffectInType,
+        substituteTypeInType)

--- a/implementation/src/Subrow.hs
+++ b/implementation/src/Subrow.hs
@@ -1,4 +1,6 @@
-module Subrow (subrow) where
+module Subrow
+  ( subrow
+  ) where
 
 import Syntax (Row(..), rowContains)
 

--- a/implementation/src/Syntax.hs
+++ b/implementation/src/Syntax.hs
@@ -15,68 +15,84 @@ module Syntax
   , rowContains
   , substituteEffectInRow
   , substituteEffectInType
-  , substituteTypeInType ) where
+  , substituteTypeInType
+  ) where
 
-import Test.QuickCheck
-  ( Arbitrary
-  , arbitrary
-  , frequency
-  , Gen
-  , oneof
-  , shrink )
 import qualified Data.Set as Set
+import Test.QuickCheck
+       (Arbitrary, arbitrary, frequency, Gen, oneof, shrink)
 
 -- Data types
-
 -- Metavariable for variable names: x
 -- Metavariable for effect names: z
-
 data Term -- Metavariable: e
   = EVar String
-  | EAbs String Term
-  | EApp Term Term
-  | ETAbs String Term
-  | ETApp Term Type
-  | EHandle String Term Term
-  | EAnno Term Type
+  | EAbs String
+         Term
+  | EApp Term
+         Term
+  | ETAbs String
+          Term
+  | ETApp Term
+          Type
+  | EHandle String
+            Term
+            Term
+  | EAnno Term
+          Type
   deriving (Eq, Show)
 
 data Type -- Metavariable: t
   = TVar String
-  | TArrow Type Row Type Row
-  | TForall String Type Row
+  | TArrow Type
+           Row
+           Type
+           Row
+  | TForall String
+            Type
+            Row
   deriving (Eq, Show)
 
 data Row -- Metavariable: r
   = REmpty
   | RSingleton String
-  | RUnion Row Row
+  | RUnion Row
+           Row
   deriving (Show)
 
 data HoistedSet -- Metavariable: h
   = HEmpty
-  | HSingleton Term Type Row
-  | HUnion HoistedSet HoistedSet
+  | HSingleton Term
+               Type
+               Row
+  | HUnion HoistedSet
+           HoistedSet
   deriving (Show)
 
 data Context -- Metavariable: c
   = CEmpty
-  | CTExtend Context String Type Row
-  | CKExtend Context String
+  | CTExtend Context
+             String
+             Type
+             Row
+  | CKExtend Context
+             String
   deriving (Eq, Show)
 
 data EffectMap -- Metavariable: em
   = EMEmpty
-  | EMExtend EffectMap String String
+  | EMExtend EffectMap
+             String
+             String
   deriving (Eq, Show)
 
 -- Eq instances
-
 instance Eq Row where
   (==) r1 r2 = toSet r1 == toSet r2
-    where toSet REmpty = Set.empty
-          toSet (RSingleton z) = Set.singleton z
-          toSet (RUnion r1' r2') = Set.union (toSet r1') (toSet r2')
+    where
+      toSet REmpty = Set.empty
+      toSet (RSingleton z) = Set.singleton z
+      toSet (RUnion r1' r2') = Set.union (toSet r1') (toSet r2')
 
 -- Arbitrary instances
 effects :: [String]
@@ -98,14 +114,16 @@ arbitraryTypeVar :: Gen String
 arbitraryTypeVar = oneof $ map (\e -> return e) typeVars
 
 instance Arbitrary Term where
-  arbitrary = frequency
-    [ (5, EVar <$> arbitraryTermVar)
-    , (4, EAbs <$> arbitraryTermVar <*> arbitrary)
-    , (2, EApp <$> arbitrary <*> arbitrary)
-    , (4, ETAbs <$> arbitraryTypeVar <*> arbitrary)
-    , (2, ETApp <$> arbitrary <*> arbitrary)
-    , (2, EHandle <$> arbitraryEffect <*> arbitrary <*> arbitrary)
-    , (4, EAnno <$> arbitrary <*> arbitrary) ]
+  arbitrary =
+    frequency
+      [ (5, EVar <$> arbitraryTermVar)
+      , (4, EAbs <$> arbitraryTermVar <*> arbitrary)
+      , (2, EApp <$> arbitrary <*> arbitrary)
+      , (4, ETAbs <$> arbitraryTypeVar <*> arbitrary)
+      , (2, ETApp <$> arbitrary <*> arbitrary)
+      , (2, EHandle <$> arbitraryEffect <*> arbitrary <*> arbitrary)
+      , (4, EAnno <$> arbitrary <*> arbitrary)
+      ]
   shrink (EVar _) = []
   shrink (EAbs x e) = [EAbs x' e' | (x', e') <- shrink (x, e)]
   shrink (EApp e1 e2) = [EApp e1' e2' | (e1', e2') <- shrink (e1, e2)]
@@ -116,10 +134,12 @@ instance Arbitrary Term where
   shrink (EAnno e t) = [EAnno e' t' | (e', t') <- shrink (e, t)]
 
 instance Arbitrary Type where
-  arbitrary = frequency
-    [ (16, TVar <$> arbitraryTypeVar)
-    , (3, TArrow <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
-    , (3, TForall <$> arbitraryTypeVar <*> arbitrary <*> arbitrary) ]
+  arbitrary =
+    frequency
+      [ (16, TVar <$> arbitraryTypeVar)
+      , (3, TArrow <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
+      , (3, TForall <$> arbitraryTypeVar <*> arbitrary <*> arbitrary)
+      ]
   shrink (TVar _) = []
   shrink (TArrow t1 r1 t2 r2) =
     [TArrow t1' r1' t2' r2' | (t1', r1', t2', r2') <- shrink (t1, r1, t2, r2)]
@@ -127,59 +147,60 @@ instance Arbitrary Type where
     [TForall a' t' r' | (a', t', r') <- shrink (a, t, r)]
 
 instance Arbitrary Row where
-  arbitrary = frequency
-    [ (5, pure REmpty)
-    , (5, RSingleton <$> arbitraryEffect)
-    , (3, RUnion <$> arbitrary <*> arbitrary) ]
+  arbitrary =
+    frequency
+      [ (5, pure REmpty)
+      , (5, RSingleton <$> arbitraryEffect)
+      , (3, RUnion <$> arbitrary <*> arbitrary)
+      ]
   shrink REmpty = []
   shrink (RSingleton _) = []
   shrink (RUnion r1 r2) =
     [r1, r2] ++ [RUnion r1' r2' | (r1', r2') <- shrink (r1, r2)]
 
 instance Arbitrary HoistedSet where
-  arbitrary = frequency
-    [ (5, pure HEmpty)
-    , (5, HSingleton <$> arbitrary <*> arbitrary <*> arbitrary)
-    , (3, HUnion <$> arbitrary <*> arbitrary) ]
+  arbitrary =
+    frequency
+      [ (5, pure HEmpty)
+      , (5, HSingleton <$> arbitrary <*> arbitrary <*> arbitrary)
+      , (3, HUnion <$> arbitrary <*> arbitrary)
+      ]
   shrink HEmpty = []
   shrink (HSingleton _ _ _) = []
   shrink (HUnion h1 h2) =
     [h1, h2] ++ [HUnion h1' h2' | (h1', h2') <- shrink (h1, h2)]
 
 instance Arbitrary Context where
-  arbitrary = frequency
-    [ (2, pure CEmpty)
-    , (3, CTExtend
-        <$> arbitrary
-        <*> arbitraryTermVar
-        <*> arbitrary
-        <*> arbitrary)
-    , (3, CKExtend <$> arbitrary <*> arbitraryTypeVar) ]
+  arbitrary =
+    frequency
+      [ (2, pure CEmpty)
+      , ( 3
+        , CTExtend <$> arbitrary <*> arbitraryTermVar <*> arbitrary <*>
+          arbitrary)
+      , (3, CKExtend <$> arbitrary <*> arbitraryTypeVar)
+      ]
   shrink CEmpty = []
   shrink (CTExtend c x t r) =
     [CTExtend c' x' t' r' | (c', x', t', r') <- shrink (c, x, t, r)]
-  shrink (CKExtend c a) =
-    [CKExtend c' a' | (c', a') <- shrink (c, a)]
+  shrink (CKExtend c a) = [CKExtend c' a' | (c', a') <- shrink (c, a)]
 
 instance Arbitrary EffectMap where
-  arbitrary = frequency
-    [ (1, pure EMEmpty)
-    , (3, EMExtend
-        <$> arbitrary
-        <*> arbitraryEffect
-        <*> arbitraryTermVar) ]
+  arbitrary =
+    frequency
+      [ (1, pure EMEmpty)
+      , (3, EMExtend <$> arbitrary <*> arbitraryEffect <*> arbitraryTermVar)
+      ]
   shrink EMEmpty = []
   shrink (EMExtend c z x) =
     [EMExtend c' z' x' | (c', z', x') <- shrink (c, z, x)]
 
 -- Helper functions
-
 contextLookupType :: Context -> String -> Maybe (Type, Row)
 contextLookupType CEmpty _ = Nothing
 contextLookupType (CTExtend c x1 t r) x2 =
   if x1 == x2
-  then Just (t, r)
-  else contextLookupType c x2
+    then Just (t, r)
+    else contextLookupType c x2
 contextLookupType (CKExtend c _) x2 = contextLookupType c x2
 
 contextLookupKind :: Context -> String -> Maybe ()
@@ -187,15 +208,15 @@ contextLookupKind CEmpty _ = Nothing
 contextLookupKind (CTExtend c _ _ _) a2 = contextLookupKind c a2
 contextLookupKind (CKExtend c a1) a2 =
   if a1 == a2
-  then Just ()
-  else contextLookupKind c a2
+    then Just ()
+    else contextLookupKind c a2
 
 effectMapLookup :: EffectMap -> String -> Maybe String
 effectMapLookup EMEmpty _ = Nothing
 effectMapLookup (EMExtend em z1 x) z2 =
   if z1 == z2
-  then Just x
-  else effectMapLookup em z2
+    then Just x
+    else effectMapLookup em z2
 
 eff :: HoistedSet -> Row
 eff HEmpty = REmpty
@@ -247,8 +268,8 @@ substituteEffectInRow :: String -> Row -> Row -> Row
 substituteEffectInRow _ _ REmpty = REmpty
 substituteEffectInRow z1 r (RSingleton z2) =
   if z1 == z2
-  then r
-  else RSingleton z2
+    then r
+    else RSingleton z2
 substituteEffectInRow z r1 (RUnion r2 r3) =
   RUnion (substituteEffectInRow z r1 r2) (substituteEffectInRow z r1 r3)
 
@@ -264,13 +285,16 @@ substituteEffectInType z r1 (TForall a t r2) =
   TForall a (substituteEffectInType z r1 t) (substituteEffectInRow z r1 r2)
 
 substituteTypeInType :: String -> Type -> Type -> Type
-substituteTypeInType a1 t (TVar a2) = if a1 == a2 then t else (TVar a2)
+substituteTypeInType a1 t (TVar a2) =
+  if a1 == a2
+    then t
+    else (TVar a2)
 substituteTypeInType a t3 (TArrow t1 r1 t2 r2) =
   TArrow (substituteTypeInType a t3 t1) r1 (substituteTypeInType a t3 t2) r2
 substituteTypeInType a1 t1 (TForall a2 t2 r) =
   if a1 == a2
-  then TForall a2 t2 r
-  else TForall a2 (substituteTypeInType a1 t1 t2) r
+    then TForall a2 t2 r
+    else TForall a2 (substituteTypeInType a1 t1 t2) r
 
 rowContains :: String -> Row -> Bool
 rowContains _ REmpty = False

--- a/implementation/test/ErrorSpec.hs
+++ b/implementation/test/ErrorSpec.hs
@@ -1,9 +1,9 @@
-module ErrorSpec (errorSpec) where
+module ErrorSpec
+  ( errorSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 errorSpec :: Spec
-errorSpec = describe "error" $
-  it "should be correct" $ pending
+errorSpec = describe "error" $ it "should be correct" $ pending

--- a/implementation/test/InferenceSpec.hs
+++ b/implementation/test/InferenceSpec.hs
@@ -1,9 +1,10 @@
-module InferenceSpec (inferenceSpec) where
+module InferenceSpec
+  ( inferenceSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 inferenceSpec :: Spec
-inferenceSpec = describe "infer" $ do
-  it "gives the correct type and effect row" $ pending
+inferenceSpec =
+  describe "infer" $ do it "gives the correct type and effect row" $ pending

--- a/implementation/test/LexerSpec.hs
+++ b/implementation/test/LexerSpec.hs
@@ -1,9 +1,9 @@
-module LexerSpec (lexerSpec) where
+module LexerSpec
+  ( lexerSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 lexerSpec :: Spec
-lexerSpec = describe "alexScanTokens" $
-  it "should be correct" $ pending
+lexerSpec = describe "alexScanTokens" $ it "should be correct" $ pending

--- a/implementation/test/LibSpec.hs
+++ b/implementation/test/LibSpec.hs
@@ -7,12 +7,12 @@ import SyntaxSpec (syntaxSpec)
 import Test.Hspec (hspec)
 
 -- The QuickCheck specs
-
 main :: IO ()
-main = hspec $ do
-  errorSpec
-  inferenceSpec
-  lexerSpec
-  parserSpec
-  subrowSpec
-  syntaxSpec
+main =
+  hspec $ do
+    errorSpec
+    inferenceSpec
+    lexerSpec
+    parserSpec
+    subrowSpec
+    syntaxSpec

--- a/implementation/test/ParserSpec.hs
+++ b/implementation/test/ParserSpec.hs
@@ -1,9 +1,9 @@
-module ParserSpec (parserSpec) where
+module ParserSpec
+  ( parserSpec
+  ) where
 
 import Test.Hspec (Spec, describe, it, pending)
 
 -- The QuickCheck specs
-
 parserSpec :: Spec
-parserSpec = describe "parse" $
-  it "should be correct" $ pending
+parserSpec = describe "parse" $ it "should be correct" $ pending

--- a/implementation/test/SubrowSpec.hs
+++ b/implementation/test/SubrowSpec.hs
@@ -1,4 +1,6 @@
-module SubrowSpec (subrowSpec) where
+module SubrowSpec
+  ( subrowSpec
+  ) where
 
 import Lib (Row(..), effects, rowContains, subrow)
 import Test.Hspec (Spec, describe, it)
@@ -6,17 +8,17 @@ import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
 import Test.QuickCheck (property)
 
 -- Helper functions
-
 contained :: Row -> Row -> Bool
 contained r1 r2 =
   all (\z -> not (rowContains z r1) || rowContains z r2) effects
 
 -- The QuickCheck specs
-
 specContainedIffSubrow :: Row -> Row -> Bool
 specContainedIffSubrow r1 r2 = contained r1 r2 == subrow r1 r2
 
 subrowSpec :: Spec
-subrowSpec = modifyMaxSuccess (const 100000) $ describe "subrow" $ do
-  it "returns True for r1 <= r2 iff r2 contains all the effects in r1" $ do
-    property specContainedIffSubrow
+subrowSpec =
+  modifyMaxSuccess (const 100000) $
+  describe "subrow" $ do
+    it "returns True for r1 <= r2 iff r2 contains all the effects in r1" $ do
+      property specContainedIffSubrow

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -1,18 +1,15 @@
-module SyntaxSpec (syntaxSpec) where
+module SyntaxSpec
+  ( syntaxSpec
+  ) where
 
 import Lib
-  ( Context(..)
-  , EffectMap(..)
-  , Row(..)
-  , Type(..)
-  , contextLookupType
-  , effectMapLookup )
+       (Context(..), EffectMap(..), Row(..), Type(..), contextLookupType,
+        effectMapLookup)
 import Test.Hspec (Spec, describe, it)
 import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
 import Test.QuickCheck (property)
 
 -- The QuickCheck specs
-
 specContextLookupAfterExtend :: Context -> String -> Type -> Row -> Bool
 specContextLookupAfterExtend c x t r =
   contextLookupType (CTExtend c x t r) x == Just (t, r)
@@ -31,19 +28,19 @@ specEffectMapLookupAfterExtend em z x =
 specEffectMapExtendAfterLookup :: EffectMap -> String -> String -> Bool
 specEffectMapExtendAfterLookup em z1 z2 =
   case effectMapLookup em z1 of
-    Just x ->
-      effectMapLookup (EMExtend em z1 x) z2 == effectMapLookup em z2
+    Just x -> effectMapLookup (EMExtend em z1 x) z2 == effectMapLookup em z2
     Nothing -> True
 
 syntaxSpec :: Spec
-syntaxSpec = modifyMaxSuccess (const 100000) $ do
-  describe "contextLookupType" $ do
-    it "contextLookupType (CTExtend c x t r) x == Just (t, r)" $ do
-      property specContextLookupAfterExtend
-    it "CTExtend em x t r == CTExtend (contextLookupType em x) x t r" $ do
-      property specContextExtendAfterLookup
-  describe "effectMapLookup" $ do
-    it "effectMapLookup (EMExtend em z x) z == Just x" $ do
-      property specEffectMapLookupAfterExtend
-    it "EMExtend em z x == EMExtend (effectMapLookup em z) z x" $ do
-      property specEffectMapExtendAfterLookup
+syntaxSpec =
+  modifyMaxSuccess (const 100000) $ do
+    describe "contextLookupType" $ do
+      it "contextLookupType (CTExtend c x t r) x == Just (t, r)" $ do
+        property specContextLookupAfterExtend
+      it "CTExtend em x t r == CTExtend (contextLookupType em x) x t r" $ do
+        property specContextExtendAfterLookup
+    describe "effectMapLookup" $ do
+      it "effectMapLookup (EMExtend em z x) z == Just x" $ do
+        property specEffectMapLookupAfterExtend
+      it "EMExtend em z x == EMExtend (effectMapLookup em z) z x" $ do
+        property specEffectMapExtendAfterLookup

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -17,6 +17,7 @@ FROM debian:stretch
 #       are installed.
 #   - Free up 2G of disk space by deleting documentation for the packages.
 #   - Create a user.
+#   - Install brittany, a Haskell source code formatter.
 RUN \
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
@@ -27,10 +28,11 @@ RUN \
     texlive-full && \
   pip install awscli && \
   curl -sSL https://get.haskellstack.org/ | sh && \
-  stack --resolver lts-9.8 setup && \
+  stack --resolver lts-10.3 setup && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /usr/share/doc && \
-  useradd --user-group --create-home user
+  useradd --user-group --create-home user && \
+  su user -c 'stack install brittany'
 
 # Set the default user.
 USER user:user


### PR DESCRIPTION
Add automatic formatting for Haskell code. Now you can run `make format` to automatically format every Haskell file in the repo. Also, the CI will fail if the formatting doesn't match what the autoformatter does (so it will catch you if you forget to run `make format`).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-hindent.pdf) is a link to the PDF generated from this PR.
