### PR TITLE
Prevent Travis from killing the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ dist: trusty
 language: generic
 sudo: required
 services: docker
-script: make docker-build TRAVIS_DEPLOY=true
+script:
+  - while sleep 1m; do echo "=====[ still running ]====="; done &
+  - make docker-build TRAVIS_DEPLOY=true
+  - kill %1


### PR DESCRIPTION
Add some simple logic to print a message every minute to prevent Travis from thinking the build is stuck.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-travis-wait.pdf) is a link to the PDF generated from this PR.
