### PR TITLE
Formalize monomorphic effects as types

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -72,6 +72,7 @@
 \newcommand\eTAbs[2]{\Lambda #1 \; . \; #2}
 \newcommand\eTApp[2]{#1 \; #2}
 \newcommand\eHandle[3]{\textbf{handle} \; #1 \; \textbf{with} \; #2 \; \textbf{in} \; #3}
+\newcommand\eEffect[5]{\textbf{effect} \; \anno{#1}{#2} \; \textbf{with} \; \tEmbellished{#3}{#4} \; \textbf{in} \; #5}
 \newcommand\eAnno[2]{\anno{#1}{#2}}
 
 % Types
@@ -98,16 +99,15 @@
 \newcommand\effectMap{\Sigma}
 \newcommand\emMap[2]{#1 \mapsto #2}
 \newcommand\emEmpty{\varnothing}
-\newcommand\emExtend[3]{#1, \emMap{#2}{#3}}
+\newcommand\emExtend[4]{#1, \emMap{#2}{\tEmbellished{#3}{#4}}}
 
 % Judgments
 \newcommand\subrowSym{\subseteq}
 \newcommand\nSubrowSym{\nsubseteq}
 \newcommand\subrow[2]{#1 \subrowSym #2}
 \newcommand\nSubrow[2]{#1 \nSubrowSym #2}
-\newcommand\checkType[5]{#1; #2 \vdash #3 \Downarrow \tEmbellished{#4}{#5}}
-\newcommand\inferType[5]{#1; #2 \vdash #3 \Uparrow \tEmbellished{#4}{#5}}
-\newcommand\wellFormed[2]{#1; #2 \; \text{well-formed}}
+\newcommand\checkType[5]{#1 ; #2 \vdash #3 \Downarrow \tEmbellished{#4}{#5}}
+\newcommand\inferType[5]{#1 ; #2 \vdash #3 \Uparrow \tEmbellished{#4}{#5}}
 
 %%%%%%%%%%%%%%%%%%%%%
 % The specification %
@@ -150,7 +150,8 @@
               & $\eApp{\term}{\term}$ & application \\
               & $\eTAbs{\tVar}{\term}$ & type abstraction \\
               & $\eTApp{\term}{\type}$ & type application \\
-              & $\eHandle{\effect}{\term}{\term}$ & effect handler \\
+              & $\eEffect{\eVar}{\tVar}{\type}{\row}{\term}$ & effect definition \\
+              & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
               & $\eAnno{\term}{\type}$ & type annotation \\
               \\
               $\type \Coloneqq$ & & types: \\
@@ -160,7 +161,7 @@
               \\
               $\row \Coloneqq$ & & rows: \\
               & $\rEmpty$ & empty row \\
-              & $\rSingleton{\effect}$ & singleton row \\
+              & $\rSingleton{\tVar}$ & singleton row \\
               & $\rUnion{\row}{\row}$ & row union \\
               \\
               $\context \Coloneqq$ & & contexts: \\
@@ -170,7 +171,7 @@
               \\
               $\effectMap \Coloneqq$ & & effect maps: \\
               & $\emEmpty$ & empty effect map \\
-              & $\emExtend{\effectMap}{\effect}{\eVar}$ & effect binding \\
+              & $\emExtend{\effectMap}{\tVar}{\type}{\row}$ & effect binding \\
             \end{tabular}
           \end{center}
 
@@ -243,27 +244,39 @@
           \medskip
 
           \begin{prooftree}
-              \AxiomC{\Shortstack[c]{
-                {$\tEmbellished{\type_2}{\row_2} = \apply{\context}{\apply{\effectMap}{\effect}}$}
-                {$\type_3 = \substitute{\type_2}{\rSingleton{\effect}}{\row_1}$}
-                {$\row_3 = \substitute{\row_2}{\rSingleton{\effect}}{\row_1}$}
-                {$\checkType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
-                {$\inferType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\effect}}}$}
-              }}
-            \RightLabel{(\textsc{T-Handle1})}
-            \UnaryInfC{$\inferType{\context}{\effectMap}{\eHandle{\effect}{\term_1}{\term_2}}{\type_1}{\row_1}$}
+              \AxiomC{$\inferType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row}$}
+            \RightLabel{(\textsc{T-Effect1})}
+            \UnaryInfC{$\inferType{\context}{\effectMap}{\eEffect{\eVar}{\tVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\checkType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row}$}
+            \RightLabel{(\textsc{T-Effect2})}
+            \UnaryInfC{$\checkType{\context}{\effectMap}{\eEffect{\eVar}{\tVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
           \end{prooftree}
 
           \begin{prooftree}
               \AxiomC{\Shortstack[c]{
-                {$\tEmbellished{\type_2}{\row_2} = \apply{\context}{\apply{\effectMap}{\effect}}$}
-                {$\type_3 = \substitute{\type_2}{\rSingleton{\effect}}{\row_1}$}
-                {$\row_3 = \substitute{\row_2}{\rSingleton{\effect}}{\row_1}$}
+                {$\tEmbellished{\type_2}{\row_2} = \apply{\effectMap}{\tVar}$}
+                {$\type_3 = \substitute{\type_2}{\rSingleton{\tVar}}{\row_1}$}
+                {$\row_3 = \substitute{\row_2}{\rSingleton{\tVar}}{\row_1}$}
                 {$\checkType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
-                {$\checkType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\effect}}}$}
+                {$\inferType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
+              }}
+            \RightLabel{(\textsc{T-Handle1})}
+            \UnaryInfC{$\inferType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{\Shortstack[c]{
+                {$\tEmbellished{\type_2}{\row_2} = \apply{\effectMap}{\tVar}$}
+                {$\type_3 = \substitute{\type_2}{\rSingleton{\tVar}}{\row_1}$}
+                {$\row_3 = \substitute{\row_2}{\rSingleton{\tVar}}{\row_1}$}
+                {$\checkType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
+                {$\checkType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
               }}
             \RightLabel{(\textsc{T-Handle2})}
-            \UnaryInfC{$\checkType{\context}{\effectMap}{\eHandle{\effect}{\term_1}{\term_2}}{\type_1}{\row_1}$}
+            \UnaryInfC{$\checkType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
           \end{prooftree}
 
           \begin{prooftree}
@@ -282,45 +295,4 @@
           \caption{Type inference (part 2)}\label{fig:typing_2}
         \end{mdframed}
       \end{figure}
-
-      \begin{figure}[H]
-        \begin{mdframed}[backgroundcolor=none]
-          \begin{center}
-            \framebox{$\wellFormed{\context}{\effectMap}$}
-          \end{center}
-
-          \medskip
-
-          \begin{prooftree}
-              \AxiomC{}
-            \RightLabel{(\textsc{WF-Empty})}
-            \UnaryInfC{$\wellFormed{\context}{\emEmpty}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\wellFormed{\context}{\effectMap}$}
-              \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\type}{\row}$}
-              \AxiomC{$\subrow{\rSingleton{\effect}}{\row}$}
-            \RightLabel{(\textsc{WF-Effect1})}
-            \TrinaryInfC{$\wellFormed{\context}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\wellFormed{\cTExtend{\context}{\eVar}{\type_2}{\row_2}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-              \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\parens{\tArrow{\type_1}{\row_1}{\type_2}{\row_2}}}{\row_3}$}
-            \RightLabel{(\textsc{WF-Effect2})}
-            \BinaryInfC{$\wellFormed{\context}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\wellFormed{\cTExtend{\cKExtend{\context}{\tVar}}{\eVar}{\type}{\row_1}}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-              \AxiomC{$\apply{\context}{\eVar} = \tEmbellished{\parens{\tForall{\tVar}{\type}{\row_1}}}{\row_2}$}
-            \RightLabel{(\textsc{WF-Effect3})}
-            \BinaryInfC{$\wellFormed{\context}{\emExtend{\effectMap}{\effect}{\eVar}}$}
-          \end{prooftree}
-
-          \caption{Type and effect context well-formedness}\label{fig:context_well_formedness}
-        \end{mdframed}
-      \end{figure}
-
 \end{document}


### PR DESCRIPTION
Add kinds (for use later), and effect rules for user-defined monomorphic effects.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-recursive-types-version.pdf) is a link to the PDF generated from this PR.
