### PR TITLE
Remove a useless macro

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -97,9 +97,8 @@
 % Effect map
 \newcommand\effect{e}
 \newcommand\effectMap{\Sigma}
-\newcommand\emMap[2]{#1 \mapsto #2}
 \newcommand\emEmpty{\varnothing}
-\newcommand\emExtend[4]{#1, \emMap{#2}{\tEmbellished{#3}{#4}}}
+\newcommand\emExtend[4]{#1, #2 \mapsto \tEmbellished{#3}{#4}}
 
 % Judgments
 \newcommand\subrowSym{\subseteq}


### PR DESCRIPTION
Remove a useless macro.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-em-map.pdf) is a link to the PDF generated from this PR.
