### PR TITLE
Introduce separate types for term and type variables

### DIFF
--- a/implementation/src/Lib.hs
+++ b/implementation/src/Lib.hs
@@ -4,7 +4,9 @@ module Lib
   , Partial
   , Row(..)
   , Term(..)
+  , TermVar(..)
   , Type(..)
+  , TypeVar(..)
   , abort
   , assert
   , check
@@ -32,7 +34,9 @@ import Syntax
   , EffectMap(..)
   , Row(..)
   , Term(..)
+  , TermVar(..)
   , Type(..)
+  , TypeVar(..)
   , contextLookupKind
   , contextLookupType
   , effectMapLookup

--- a/implementation/src/Parser.y
+++ b/implementation/src/Parser.y
@@ -2,7 +2,7 @@
 module Parser (parse) where
 
 import Lexer (Token(..))
-import Lib (Term(..), Type(..))
+import Lib (Term(..), TermVar(..), Type(..), TypeVar(..))
 }
 
 %name parse
@@ -23,10 +23,10 @@ import Lib (Term(..), Type(..))
 
 %%
 
-Term : x                           { EVar $1 }
-     | lambda x arrow Term         { EAbs $2 $4 }
+Term : x                           { EVar (TermVar $1) }
+     | lambda x arrow Term         { EAbs (TermVar $2) $4 }
      | Term Term                   { EApp $1 $2 }
-     | handle x with Term in Term  { EHandle $2 $4 $6 }
+     | handle x with Term in Term  { EHandle (TypeVar $2) $4 $6 }
      | '(' Term ')'                { $2 }
 {
 parseError :: [Token] -> a

--- a/implementation/test/SyntaxSpec.hs
+++ b/implementation/test/SyntaxSpec.hs
@@ -4,7 +4,9 @@ import Lib
   ( Context(..)
   , EffectMap(..)
   , Row(..)
+  , TermVar(..)
   , Type(..)
+  , TypeVar(..)
   , contextLookupType
   , effectMapLookup )
 import Test.Hspec (Spec, describe, it)
@@ -13,21 +15,21 @@ import Test.QuickCheck (property)
 
 -- The QuickCheck specs
 
-specContextLookupAfterExtend :: Context -> String -> Type -> Row -> Bool
+specContextLookupAfterExtend :: Context -> TermVar -> Type -> Row -> Bool
 specContextLookupAfterExtend c x t r =
   contextLookupType (CTExtend c x t r) x == Just (t, r)
 
-specContextExtendAfterLookup :: Context -> String -> String -> Bool
+specContextExtendAfterLookup :: Context -> TermVar -> TermVar -> Bool
 specContextExtendAfterLookup c x1 x2 = case contextLookupType c x1 of
   Just (t, r) ->
     contextLookupType (CTExtend c x1 t r) x2 == contextLookupType c x2
   Nothing -> True
 
-specEffectMapLookupAfterExtend :: EffectMap -> String -> Type -> Row -> Bool
+specEffectMapLookupAfterExtend :: EffectMap -> TypeVar -> Type -> Row -> Bool
 specEffectMapLookupAfterExtend em a t r =
   effectMapLookup (EMExtend em a t r) a == Just (t, r)
 
-specEffectMapExtendAfterLookup :: EffectMap -> String -> String -> Bool
+specEffectMapExtendAfterLookup :: EffectMap -> TypeVar -> TypeVar -> Bool
 specEffectMapExtendAfterLookup em a1 a2 = case effectMapLookup em a1 of
   Just (t, r) ->
     effectMapLookup (EMExtend em a1 t r) a2 == effectMapLookup em a2


### PR DESCRIPTION
Before, we were using strings for term and type variables. This meant our property checks were mostly useless because QuickCheck would generate arbitrary strings in the specs rather than using the set of term and type variable strings that we were using in the arbitrary instances of other datatypes.

Here we introduce new types for term and type variables, so that we can define arbitrary instances that will be used by both QuickCheck as well as other arbitrary instances.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-types-for-variables.pdf) is a link to the PDF generated from this PR.
