### PR TITLE
Add a declarative version of the type system

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -68,6 +68,7 @@
 \newcommand\term{t}
 \newcommand\eVar{x}
 \newcommand\eAbs[2]{\lambda #1 \; . \; #2}
+\newcommand\eAbsAnno[4]{\lambda \anno{#1}{\tEmbellished{#2}{#3}} \; . \; #4}
 \newcommand\eApp[2]{#1 \; #2}
 \newcommand\eTAbs[2]{\Lambda #1 \; . \; #2}
 \newcommand\eTApp[2]{#1 \; #2}
@@ -104,6 +105,7 @@
 \newcommand\nSubrowSym{\nsubseteq}
 \newcommand\subrow[2]{#1 \subrowSym #2}
 \newcommand\nSubrow[2]{#1 \nSubrowSym #2}
+\newcommand\hasType[5]{#1 ; #2 \vdash \anno{#3}{\tEmbellished{#4}{#5}}}
 \newcommand\checkType[5]{#1 ; #2 \vdash #3 \Downarrow \tEmbellished{#4}{#5}}
 \newcommand\inferType[5]{#1 ; #2 \vdash #3 \Uparrow \tEmbellished{#4}{#5}}
 
@@ -144,13 +146,12 @@
             \begin{tabular}{l l l}
               $\term \Coloneqq$ & & terms: \\
               & $\eVar$ & variable \\
-              & $\eAbs{\eVar}{\term}$ & abstraction \\
+              & $\eAbsAnno{\eVar}{\type}{\row}{\term}$ & abstraction \\
               & $\eApp{\term}{\term}$ & application \\
               & $\eTAbs{\tVar}{\term}$ & type abstraction \\
               & $\eTApp{\term}{\type}$ & type application \\
               & $\eEffect{\tVar}{\eVar}{\type}{\row}{\term}$ & effect definition \\
               & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
-              & $\eAnno{\term}{\type}$ & type annotation \\
               \\
               $\type \Coloneqq$ & & types: \\
               & $\tVar$ & type variable \\
@@ -183,6 +184,99 @@
         \begin{mdframed}[backgroundcolor=none]
           \begin{center}
             \framebox{
+              $\hasType{\context}{\effectMap}{\term}{\type}{\row}$
+            }
+          \end{center}
+
+          \medskip
+
+          \begin{prooftree}
+              \AxiomC{$\tEmbellished{\type}{\row} = \apply{\context}{\eVar}$}
+            \RightLabel{(\textsc{T-Var})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\type}{\row}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_2}{\row_2}}{\effectMap}{\term}{\type_1}{\row_1}$}
+            \RightLabel{(\textsc{T-Abs})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eAbsAnno{\eVar}{\type_2}{\row_2}{\term}}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\rEmpty}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\row_3}$}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
+            \RightLabel{(\textsc{T-App})}
+            \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\rUnion{\row_1}{\row_3}}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\tVar \notin \dom{\context}$}
+              \AxiomC{$\hasType{\cKExtend{\context}{\tVar}}{\effectMap}{\term}{\type}{\row}$}
+            \RightLabel{(\textsc{T-TAbs})}
+            \BinaryInfC{$\hasType{\context}{\effectMap}{\eTAbs{\tVar}{\term}}{\parens{\tForall{\tVar}{\type}{\row}}}{\rEmpty}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term}{\parens{\tForall{\tVar}{\type_1}{\row_1}}}{\row_2}$}
+            \RightLabel{(\textsc{T-TApp})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\rUnion{\row_1}{\row_2}}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row_2}$}
+            \RightLabel{(\textsc{T-Effect})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{\Shortstack[c]{
+                {$\tEmbellished{\type_2}{\row_2} = \apply{\effectMap}{\tVar}$}
+                {$\type_3 = \substitute{\type_2}{\rSingleton{\tVar}}{\row_1}$}
+                {$\row_3 = \substitute{\row_2}{\rSingleton{\tVar}}{\row_1}$}
+                {$\hasType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
+                {$\hasType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
+              }}
+            \RightLabel{(\textsc{T-Handle})}
+            \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
+          \end{prooftree}
+
+          \begin{prooftree}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_1}$}
+              \AxiomC{$\subrow{\row_1}{\row_2}$}
+            \RightLabel{(\textsc{T-SubRow})}
+            \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_2}$}
+          \end{prooftree}
+
+          \caption{Typing}\label{fig:typing}
+        \end{mdframed}
+      \end{figure}
+
+    \subsection{Type inference}
+
+      \begin{figure}[H]
+        \begin{mdframed}[backgroundcolor=none]
+          \begin{center}
+            \begin{tabular}{l l l}
+              $\term \Coloneqq$ & & terms: \\
+              & $\eVar$ & variable \\
+              & $\eAbs{\eVar}{\term}$ & abstraction \\
+              & $\eApp{\term}{\term}$ & application \\
+              & $\eTAbs{\tVar}{\term}$ & type abstraction \\
+              & $\eTApp{\term}{\type}$ & type application \\
+              & $\eEffect{\tVar}{\eVar}{\type}{\row}{\term}$ & effect definition \\
+              & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
+              & $\eAnno{\term}{\type}$ & type annotation \\
+            \end{tabular}
+          \end{center}
+
+          \caption{Syntax for terms in type inference}\label{fig:syntax_inference}
+        \end{mdframed}
+      \end{figure}
+
+      \begin{figure}[H]
+        \begin{mdframed}[backgroundcolor=none]
+          \begin{center}
+            \framebox{
               $\checkType{\context}{\effectMap}{\term}{\type}{\row}$
               \qquad
               $\inferType{\context}{\effectMap}{\term}{\type}{\row}$
@@ -206,7 +300,7 @@
 
           \begin{prooftree}
               \AxiomC{$\inferType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\row_3}$}
-              \AxiomC{$\checkType{\context}{\effectMap}{\term_2}{\type_2}{\rUnion{\row_2}{\row_3}}$}
+              \AxiomC{$\checkType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
               \AxiomC{$\subrow{\row_1}{\row_3}$}
             \RightLabel{(\textsc{T-App})}
             \TrinaryInfC{$\inferType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\row_3}$}
@@ -294,4 +388,5 @@
           \caption{Type inference (part 2)}\label{fig:typing_2}
         \end{mdframed}
       \end{figure}
+
 \end{document}


### PR DESCRIPTION
Add a declarative version of the type system to make the metatheory simpler. In particular, we hope that this will make the soundness proof easier.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-declarative-typing.pdf) is a link to the PDF generated from this PR.
