### PR TITLE
Make the declarative type system deterministic

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -205,8 +205,9 @@
           \begin{prooftree}
               \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\row_3}$}
               \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
+              \AxiomC{$\subrow{\row_1}{\row_3}$}
             \RightLabel{(\textsc{T-App})}
-            \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\rUnion{\row_1}{\row_3}}$}
+            \TrinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\row_3}$}
           \end{prooftree}
 
           \begin{prooftree}
@@ -218,8 +219,9 @@
 
           \begin{prooftree}
               \AxiomC{$\hasType{\context}{\effectMap}{\term}{\parens{\tForall{\tVar}{\type_1}{\row_1}}}{\row_2}$}
+              \AxiomC{$\subrow{\row_1}{\row_2}$}
             \RightLabel{(\textsc{T-TApp})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\rUnion{\row_1}{\row_2}}$}
+            \BinaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\row_2}$}
           \end{prooftree}
 
           \begin{prooftree}


### PR DESCRIPTION
Make the declarative type system deterministic. Specifically, the guarantee is that if you know the typing context, effect context, term, and effect row in the conclusion, then the type (and hoisted terms, if we have hoisting) is fully determined (and the choice of hoisting, if we have it, is also fully determined).

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-determinism.pdf) is a link to the PDF generated from this PR.
