### PR TITLE
Delete the declarative version of the type system

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -68,7 +68,6 @@
 \newcommand\term{t}
 \newcommand\eVar{x}
 \newcommand\eAbs[2]{\lambda #1 \; . \; #2}
-\newcommand\eAbsAnno[4]{\lambda \anno{#1}{\tEmbellished{#2}{#3}} \; . \; #4}
 \newcommand\eApp[2]{#1 \; #2}
 \newcommand\eTAbs[2]{\Lambda #1 \; . \; #2}
 \newcommand\eTApp[2]{#1 \; #2}
@@ -146,12 +145,13 @@
             \begin{tabular}{l l l}
               $\term \Coloneqq$ & & terms: \\
               & $\eVar$ & variable \\
-              & $\eAbsAnno{\eVar}{\type}{\row}{\term}$ & abstraction \\
+              & $\eAbs{\eVar}{\term}$ & abstraction \\
               & $\eApp{\term}{\term}$ & application \\
               & $\eTAbs{\tVar}{\term}$ & type abstraction \\
               & $\eTApp{\term}{\type}$ & type application \\
               & $\eEffect{\tVar}{\eVar}{\type}{\row}{\term}$ & effect definition \\
               & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
+              & $\eAnno{\term}{\type}$ & type annotation \\
               \\
               $\type \Coloneqq$ & & types: \\
               & $\tVar$ & type variable \\
@@ -179,99 +179,6 @@
       \end{figure}
 
     \subsection{Typing}
-
-      \begin{figure}[H]
-        \begin{mdframed}[backgroundcolor=none]
-          \begin{center}
-            \framebox{
-              $\hasType{\context}{\effectMap}{\term}{\type}{\row}$
-            }
-          \end{center}
-
-          \medskip
-
-          \begin{prooftree}
-              \AxiomC{$\tEmbellished{\type}{\row} = \apply{\context}{\eVar}$}
-            \RightLabel{(\textsc{T-Var})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\type}{\row}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_2}{\row_2}}{\effectMap}{\term}{\type_1}{\row_1}$}
-            \RightLabel{(\textsc{T-Abs})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eAbsAnno{\eVar}{\type_2}{\row_2}{\term}}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\rEmpty}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\row_3}$}
-              \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
-            \RightLabel{(\textsc{T-App})}
-            \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\rUnion{\row_1}{\row_3}}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\tVar \notin \dom{\context}$}
-              \AxiomC{$\hasType{\cKExtend{\context}{\tVar}}{\effectMap}{\term}{\type}{\row}$}
-            \RightLabel{(\textsc{T-TAbs})}
-            \BinaryInfC{$\hasType{\context}{\effectMap}{\eTAbs{\tVar}{\term}}{\parens{\tForall{\tVar}{\type}{\row}}}{\rEmpty}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\context}{\effectMap}{\term}{\parens{\tForall{\tVar}{\type_1}{\row_1}}}{\row_2}$}
-            \RightLabel{(\textsc{T-TApp})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\rUnion{\row_1}{\row_2}}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row_2}$}
-            \RightLabel{(\textsc{T-Effect})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{\Shortstack[c]{
-                {$\tEmbellished{\type_2}{\row_2} = \apply{\effectMap}{\tVar}$}
-                {$\type_3 = \substitute{\type_2}{\rSingleton{\tVar}}{\row_1}$}
-                {$\row_3 = \substitute{\row_2}{\rSingleton{\tVar}}{\row_1}$}
-                {$\hasType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
-                {$\hasType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
-              }}
-            \RightLabel{(\textsc{T-Handle})}
-            \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_1}$}
-              \AxiomC{$\subrow{\row_1}{\row_2}$}
-            \RightLabel{(\textsc{T-SubRow})}
-            \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_2}$}
-          \end{prooftree}
-
-          \caption{Typing}\label{fig:typing}
-        \end{mdframed}
-      \end{figure}
-
-    \subsection{Type inference}
-
-      \begin{figure}[H]
-        \begin{mdframed}[backgroundcolor=none]
-          \begin{center}
-            \begin{tabular}{l l l}
-              $\term \Coloneqq$ & & terms: \\
-              & $\eVar$ & variable \\
-              & $\eAbs{\eVar}{\term}$ & abstraction \\
-              & $\eApp{\term}{\term}$ & application \\
-              & $\eTAbs{\tVar}{\term}$ & type abstraction \\
-              & $\eTApp{\term}{\type}$ & type application \\
-              & $\eEffect{\tVar}{\eVar}{\type}{\row}{\term}$ & effect definition \\
-              & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
-              & $\eAnno{\term}{\type}$ & type annotation \\
-            \end{tabular}
-          \end{center}
-
-          \caption{Syntax for terms in type inference}\label{fig:syntax_inference}
-        \end{mdframed}
-      \end{figure}
 
       \begin{figure}[H]
         \begin{mdframed}[backgroundcolor=none]


### PR DESCRIPTION
Delete the declarative version of the type system because it would lead to non-deterministic choices of hoisted term sets. The inference algorithm will be the specification.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-inference.pdf) is a link to the PDF generated from this PR.
