### PR TITLE
Introduce syntactic sugar for either checking or inference mode

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -107,6 +107,7 @@
 \newcommand\hasType[5]{#1 ; #2 \vdash \anno{#3}{\tEmbellished{#4}{#5}}}
 \newcommand\checkType[5]{#1 ; #2 \vdash #3 \Downarrow \tEmbellished{#4}{#5}}
 \newcommand\inferType[5]{#1 ; #2 \vdash #3 \Uparrow \tEmbellished{#4}{#5}}
+\newcommand\checkOrInferType[5]{#1 ; #2 \vdash #3 \Updownarrow \tEmbellished{#4}{#5}}
 
 %%%%%%%%%%%%%%%%%%%%%
 % The specification %
@@ -227,32 +228,10 @@
             \BinaryInfC{$\inferType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\row_2}$}
           \end{prooftree}
 
-          \caption{Type inference (part 1)}\label{fig:typing_1}
-        \end{mdframed}
-      \end{figure}
-
-      \begin{figure}[H]
-        \begin{mdframed}[backgroundcolor=none]
-          \begin{center}
-            \framebox{
-              $\checkType{\context}{\effectMap}{\term}{\type}{\row}$
-              \qquad
-              $\inferType{\context}{\effectMap}{\term}{\type}{\row}$
-            }
-          \end{center}
-
-          \medskip
-
           \begin{prooftree}
-              \AxiomC{$\inferType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row_2}$}
-            \RightLabel{(\textsc{T-Effect1})}
-            \UnaryInfC{$\inferType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{$\checkType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row_2}$}
-            \RightLabel{(\textsc{T-Effect2})}
-            \UnaryInfC{$\checkType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
+              \AxiomC{$\checkOrInferType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row_2}$}
+            \RightLabel{(\textsc{T-Effect})}
+            \UnaryInfC{$\checkOrInferType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
           \end{prooftree}
 
           \begin{prooftree}
@@ -261,22 +240,10 @@
                 {$\type_3 = \substitute{\type_2}{\rSingleton{\tVar}}{\row_1}$}
                 {$\row_3 = \substitute{\row_2}{\rSingleton{\tVar}}{\row_1}$}
                 {$\checkType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
-                {$\inferType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
+                {$\checkOrInferType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
               }}
-            \RightLabel{(\textsc{T-Handle1})}
-            \UnaryInfC{$\inferType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
-          \end{prooftree}
-
-          \begin{prooftree}
-              \AxiomC{\Shortstack[c]{
-                {$\tEmbellished{\type_2}{\row_2} = \apply{\effectMap}{\tVar}$}
-                {$\type_3 = \substitute{\type_2}{\rSingleton{\tVar}}{\row_1}$}
-                {$\row_3 = \substitute{\row_2}{\rSingleton{\tVar}}{\row_1}$}
-                {$\checkType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
-                {$\checkType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
-              }}
-            \RightLabel{(\textsc{T-Handle2})}
-            \UnaryInfC{$\checkType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
+            \RightLabel{(\textsc{T-Handle})}
+            \UnaryInfC{$\checkOrInferType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
           \end{prooftree}
 
           \begin{prooftree}
@@ -292,7 +259,7 @@
             \BinaryInfC{$\checkType{\context}{\effectMap}{\term}{\type_1}{\row}$}
           \end{prooftree}
 
-          \caption{Type inference (part 2)}\label{fig:typing_2}
+          \caption{Type inference}\label{fig:typing}
         \end{mdframed}
       \end{figure}
 


### PR DESCRIPTION
Introduce syntactic sugar for either checking or inference mode. I'm not sure if we'll keep this, but for now it's convenient since it allows the typing rules to fit on one page.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-updown.pdf) is a link to the PDF generated from this PR.
