### PR TITLE
Document some conventions

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -208,6 +208,7 @@
         \end{figure}
 
       \subsubsection{Typing}
+        In the following rules, terms are considered equivalent up to $\alpha$-conversion, and likewise for types. Effect row union is considered associative and commutative.
 
         \begin{figure}[H]
           \begin{mdframed}[backgroundcolor=none]


### PR DESCRIPTION
Document some conventions in the typing rules.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-caveats.pdf) is a link to the PDF generated from this PR.
