### PR TITLE
Require abstractions to be pure in order to be applied

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -262,10 +262,10 @@
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\row_3}$}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\rEmpty}$}
                 \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
               \RightLabel{(\textsc{T-App})}
-              \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\rUnion{\row_1}{\row_3}}$}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\row_1}$}
             \end{prooftree}
 
             \begin{prooftree}
@@ -276,9 +276,9 @@
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\parens{\tForall{\tVar}{\type_1}{\row_1}}}{\row_2}$}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\parens{\tForall{\tVar}{\type_1}{\row}}}{\rEmpty}$}
               \RightLabel{(\textsc{T-TApp})}
-              \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\rUnion{\row_1}{\row_2}}$}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\row}$}
             \end{prooftree}
 
             \begin{prooftree}


### PR DESCRIPTION
Require abstractions to be pure in order to be applied. This is without loss of power: the `do` construct already allows us to remove the effects from impure abstractions so they can be applied. Before this change, application (of both term and type abstractions) had some redundant behavior with `do`.

Note that this only affects the core language. The source language (with hoisting) will still allow impure abstractions to be applied.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-pure-abstractions.pdf) is a link to the PDF generated from this PR.
