### PR TITLE
Re-introduce embellished types in the syntax

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -52,7 +52,7 @@
 \newtheorem{theorem}{Theorem}
 
 % Misc
-\newcommand\anno[2]{#1 : #2}
+\newcommand\anno[2]{#1 : \colorEmbellished{#2}}
 \newcommand\apply[2]{#1\parens{#2}}
 \newcommand\parens[1]{\left( #1 \right)}
 \newcommand\fv[1]{\apply{\text{fv}}{#1}}
@@ -65,15 +65,16 @@
 \makeatother
 
 % Terms
+\newcommand\colorTerm[1]{\textcolor{black}{#1}}
 \newcommand\term{t}
 \newcommand\eVar{x}
 \newcommand\eAbs[2]{\lambda #1 \; . \; #2}
-\newcommand\eAbsAnno[4]{\eAbs{\anno{#1}{\tEmbellished{#2}{#3}}}{#4}}
+\newcommand\eAbsAnno[3]{\eAbs{\anno{#1}{#2}}{#3}}
 \newcommand\eApp[2]{#1 \; #2}
 \newcommand\eTAbs[2]{\Lambda \colorType{#1} \; . \; #2}
 \newcommand\eTApp[2]{#1 \; \colorType{#2}}
 \newcommand\eHandle[3]{\textbf{handle} \; \colorType{#1} \; \textbf{with} \; #2 \; \textbf{in} \; #3}
-\newcommand\eEffect[5]{\textbf{effect} \; \colorType{#1} \; \textbf{where} \; \anno{#2}{\tEmbellished{#3}{#4}} \; \textbf{in} \; #5}
+\newcommand\eEffect[4]{\textbf{effect} \; \colorType{#1} \; \textbf{where} \; \anno{#2}{#3} \; \textbf{in} \; #4}
 \newcommand\eAnno[2]{\anno{#1}{\colorType{#2}}}
 \newcommand\eDo[3]{\textbf{do} \; #1 \leftarrow #2 \; \textbf{in} \; #3}
 
@@ -81,9 +82,13 @@
 \newcommand\colorType[1]{\textcolor[RGB]{12, 56, 150}{#1}}
 \newcommand\type{\tau}
 \newcommand\tVar{\alpha}
-\newcommand\tArrow[4]{\tEmbellished{#1}{#2} \rightarrow \tEmbellished{#3}{#4}}
-\newcommand\tForall[3]{\forall #1 \; . \; \tEmbellished{#2}{#3}}
-\newcommand\tEmbellished[2]{\colorType{#1} \; ! \; \colorRow{#2}}
+\newcommand\tArrow[2]{\colorEmbellished{#1} \rightarrow \colorEmbellished{#2}}
+\newcommand\tForall[2]{\forall #1 \; . \; \colorEmbellished{#2}}
+\newcommand\tEmbellished[2]{\colorEmbellished{\colorType{#1} \; ! \; \colorRow{#2}}}
+
+% Embellished types
+\newcommand\colorEmbellished[1]{\textcolor[RGB]{80, 140, 80}{#1}}
+\newcommand\embellishedType{\sigma}
 
 % Rows
 \newcommand\colorRow[1]{\textcolor[RGB]{150, 26, 12}{#1}}
@@ -101,23 +106,23 @@
 % Type contexts
 \newcommand\context{\Gamma}
 \newcommand\cEmpty{\varnothing}
-\newcommand\cTExtend[4]{#1, \anno{#2}{\tEmbellished{#3}{#4}}}
+\newcommand\cTExtend[3]{#1, \anno{#2}{#3}}
 \newcommand\cKExtend[2]{#1, \colorType{#2}}
 
 % Effect map
 \newcommand\effectMap{\Sigma}
 \newcommand\emEmpty{\varnothing}
-\newcommand\emExtend[4]{#1, \colorType{#2} \mapsto \colorType{\tEmbellished{#3}{#4}}}
+\newcommand\emExtend[3]{#1, \colorType{#2} \mapsto \colorEmbellished{#3}}
 
 % Judgments
 \newcommand\subrowSym{\subseteq}
 \newcommand\nSubrowSym{\nsubseteq}
 \newcommand\subrow[2]{\colorRow{#1} \subrowSym \colorRow{#2}}
 \newcommand\nSubrow[2]{\colorRow{#1} \nSubrowSym \colorRow{#2}}
-\newcommand\checkType[7]{#1 ; #2 \vdash #3 \Downarrow \colorType{\tEmbellished{#4}{#5}} \; | \; #6; #7}
-\newcommand\inferType[7]{#1 ; #2 \vdash #3 \Uparrow \colorType{\tEmbellished{#4}{#5}} \; | \; #6; #7}
-\newcommand\checkOrInferType[6]{#1 ; #2 \vdash #3 \Updownarrow \colorType{\tEmbellished{#4}{#5}} \; | \; #6}
-\newcommand\hasType[5]{#1 ; #2 \vdash \anno{#3}{\tEmbellished{#4}{#5}}}
+\newcommand\checkType[6]{#1 ; #2 \vdash #3 \Downarrow \colorType{#4} \; | \; #5; #6}
+\newcommand\inferType[6]{#1 ; #2 \vdash #3 \Uparrow \colorType{#4} \; | \; #5; #6}
+\newcommand\checkOrInferType[5]{#1 ; #2 \vdash #3 \Updownarrow \colorType{#4} \; | \; #5}
+\newcommand\hasType[4]{#1 ; #2 \vdash \anno{#3}{#4}}
 \newcommand\fresh[1]{#1 \; \text{fresh}}
 
 %%%%%%%%%%%%%%%%%%%%%
@@ -159,18 +164,21 @@
               \begin{tabular}{l l l}
                 $\term \Coloneqq$ & & terms: \\
                 & $\eVar$ & variable \\
-                & $\eAbsAnno{\eVar}{\type}{\row}{\term}$ & abstraction \\
+                & $\eAbsAnno{\eVar}{\embellishedType}{\term}$ & abstraction \\
                 & $\eApp{\term}{\term}$ & application \\
                 & $\eTAbs{\tVar}{\term}$ & type abstraction \\
                 & $\eTApp{\term}{\type}$ & type application \\
-                & $\eEffect{\tVar}{\eVar}{\type}{\row}{\term}$ & effect definition \\
+                & $\eEffect{\tVar}{\eVar}{\embellishedType}{\term}$ & effect definition \\
                 & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
                 & $\eDo{\eVar}{\term}{\term}$ & sequence \\
                 \\
                 $\colorType{\type} \Coloneqq$ & & types: \\
                 & $\colorType{\tVar}$ & type variable \\
-                & $\colorType{\tArrow{\type}{\row}{\type}{\row}}$ & arrow type \\
-                & $\colorType{\tForall{\tVar}{\type}{\row}}$ & universal type \\
+                & $\colorType{\tArrow{\embellishedType}{\embellishedType}}$ & arrow type \\
+                & $\colorType{\tForall{\tVar}{\embellishedType}}$ & universal type \\
+                \\
+                $\colorEmbellished{\embellishedType} \Coloneqq$ & & embellished types: \\
+                & $\colorType{\tEmbellished{\type}{\row}}$ & type with effects \\
                 \\
                 $\colorRow{\row} \Coloneqq$ & & rows: \\
                 & $\colorRow{\rEmpty}$ & empty row \\
@@ -179,12 +187,12 @@
                 \\
                 $\context \Coloneqq$ & & contexts: \\
                 & $\cEmpty$ & empty context \\
-                & $\cTExtend{\context}{\eVar}{\type}{\row}$ & variable binding \\
+                & $\cTExtend{\context}{\eVar}{\embellishedType}$ & variable binding \\
                 & $\cKExtend{\context}{\tVar}$ & type variable binding \\
                 \\
                 $\effectMap \Coloneqq$ & & effect maps: \\
                 & $\emEmpty$ & empty effect map \\
-                & $\emExtend{\effectMap}{\tVar}{\type}{\row}$ & effect binding \\
+                & $\emExtend{\effectMap}{\tVar}{\embellishedType}$ & effect binding \\
               \end{tabular}
             \end{center}
 
@@ -244,73 +252,72 @@
         \begin{figure}[H]
           \begin{mdframed}[backgroundcolor=none]
             \begin{center}
-              \framebox{$\hasType{\context}{\effectMap}{\term}{\type}{\row}$}
+              \framebox{$\hasType{\context}{\effectMap}{\term}{\embellishedType}$}
             \end{center}
 
             \medskip
 
             \begin{prooftree}
-                \AxiomC{$\tEmbellished{\type}{\row} = \apply{\context}{\eVar}$}
+                \AxiomC{$\colorEmbellished{\embellishedType} = \colorEmbellished{\apply{\context}{\colorTerm{\eVar}}}$}
               \RightLabel{(\textsc{T-Var})}
-              \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\type}{\row}$}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eVar}{\embellishedType}$}
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_2}{\row_2}}{\effectMap}{\term}{\type_1}{\row_1}$}
+                \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\embellishedType_2}}{\effectMap}{\term}{\embellishedType_1}$}
               \RightLabel{(\textsc{T-Abs})}
-              \UnaryInfC{$\hasType{\context}{\effectMap}{\eAbsAnno{\eVar}{\type_2}{\row_2}{\term}}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\rEmpty}$}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eAbsAnno{\eVar}{\embellishedType_2}{\term}}{\tEmbellished{\parens{\tArrow{\embellishedType_2}{\embellishedType_1}}}{\rEmpty}}$}
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\parens{\tArrow{\type_2}{\row_2}{\type_1}{\row_1}}}{\rEmpty}$}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\type_2}{\row_2}$}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\tEmbellished{\parens{\tArrow{\embellishedType_2}{\embellishedType_1}}}{\rEmpty}}$}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term_2}{\embellishedType_2}$}
               \RightLabel{(\textsc{T-App})}
-              \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\type_1}{\row_1}$}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\eApp{\term_1}{\term_2}}{\embellishedType_1}$}
             \end{prooftree}
 
             \begin{prooftree}
                 \AxiomC{$\colorType{\tVar} \notin \dom{\context}$}
-                \AxiomC{$\hasType{\cKExtend{\context}{\tVar}}{\effectMap}{\term}{\type}{\row}$}
+                \AxiomC{$\hasType{\cKExtend{\context}{\tVar}}{\effectMap}{\term}{\embellishedType}$}
               \RightLabel{(\textsc{T-TAbs})}
-              \BinaryInfC{$\hasType{\context}{\effectMap}{\eTAbs{\tVar}{\term}}{\parens{\tForall{\tVar}{\type}{\row}}}{\rEmpty}$}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\eTAbs{\tVar}{\term}}{\tEmbellished{\parens{\tForall{\tVar}{\embellishedType}}}{\rEmpty}}$}
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\parens{\tForall{\tVar}{\type_1}{\row}}}{\rEmpty}$}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term}{\tEmbellished{\parens{\tForall{\tVar}{\embellishedType}}}{\rEmpty}}$}
               \RightLabel{(\textsc{T-TApp})}
-              \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type_2}}{\substitute{\type_1}{\tVar}{\type_2}}{\row}$}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eTApp{\term}{\type}}{\substitute{\embellishedType}{\colorType{\tVar}}{\colorType{\type}}}$}
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_1}{\row_1}}{\emExtend{\effectMap}{\tVar}{\type_1}{\row_1}}{\term}{\type_2}{\row_2}$}
+                \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\embellishedType_1}}{\emExtend{\effectMap}{\tVar}{\embellishedType_1}}{\term}{\embellishedType_2}$}
               \RightLabel{(\textsc{T-Effect})}
-              \UnaryInfC{$\hasType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\type_1}{\row_1}{\term}}{\type_2}{\row_2}$}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eEffect{\tVar}{\eVar}{\embellishedType_1}{\term}}{\embellishedType_2}$}
             \end{prooftree}
 
             \begin{prooftree}
                 \AxiomC{\Shortstack[c]{
-                  {$\tEmbellished{\type_2}{\row_2} = \apply{\effectMap}{\colorType{\tVar}}$}
-                  {$\colorType{\type_3} = \colorType{\substitute{\type_2}{\colorRow{\rSingleton{\tVar}}}{\colorRow{\row_1}}}$}
-                  {$\colorRow{\row_3} = \colorRow{\substitute{\row_2}{\rSingleton{\tVar}}{\row_1}}$}
-                  {$\hasType{\context}{\effectMap}{\term_1}{\type_3}{\row_3}$}
-                  {$\hasType{\context}{\effectMap}{\term_2}{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}$}
+                  {$\colorEmbellished{\embellishedType_1} = \colorEmbellished{\apply{\effectMap}{\colorType{\tVar}}}$}
+                  {$\colorEmbellished{\embellishedType_2} = \colorEmbellished{\substitute{\embellishedType_1}{\colorRow{\rSingleton{\tVar}}}{\colorRow{\row_1}}}$}
+                  {$\hasType{\context}{\effectMap}{\term_1}{\embellishedType_2}$}
+                  {$\hasType{\context}{\effectMap}{\term_2}{\tEmbellished{\type_1}{\rUnion{\row_1}{\rSingleton{\tVar}}}}$}
                 }}
               \RightLabel{(\textsc{T-Handle})}
-              \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\type_1}{\row_1}$}
+              \UnaryInfC{$\hasType{\context}{\effectMap}{\eHandle{\tVar}{\term_1}{\term_2}}{\tEmbellished{\type_1}{\row_1}}$}
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\type_1}{\row_1}$}
-                \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\type_1}{\rEmpty}}{\effectMap}{\term_2}{\type_2}{\row_2}$}
+                \AxiomC{$\hasType{\context}{\effectMap}{\term_1}{\tEmbellished{\type_1}{\row_1}}$}
+                \AxiomC{$\hasType{\cTExtend{\context}{\eVar}{\tEmbellished{\type_1}{\rEmpty}}}{\effectMap}{\term_2}{\tEmbellished{\type_2}{\row_2}}$}
               \RightLabel{(\textsc{T-Do})}
-              \BinaryInfC{$\hasType{\context}{\effectMap}{\eDo{\eVar}{\term_1}{\term_2}}{\type_2}{\rUnion{\row_1}{\row_2}}$}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\eDo{\eVar}{\term_1}{\term_2}}{\tEmbellished{\type_2}{\rUnion{\row_1}{\row_2}}}$}
             \end{prooftree}
 
             \begin{prooftree}
-                \AxiomC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_1}$}
+              \AxiomC{$\hasType{\context}{\effectMap}{\term}{\tEmbellished{\type}{\row_1}}$}
                 \AxiomC{$\subrow{\row_1}{\row_2}$}
               \RightLabel{(\textsc{T-SubRow})}
-              \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\type}{\row_2}$}
+              \BinaryInfC{$\hasType{\context}{\effectMap}{\term}{\tEmbellished{\type}{\row_2}}$}
             \end{prooftree}
 
             \caption{Typing rules for the core language}\label{fig:core_typing}
@@ -331,7 +338,7 @@
                 & $\eApp{\term}{\term}$ & application \\
                 & $\eTAbs{\tVar}{\term}$ & type abstraction \\
                 & $\eTApp{\term}{\type}$ & type application \\
-                & $\eEffect{\tVar}{\eVar}{\type}{\row}{\term}$ & effect definition \\
+                & $\eEffect{\tVar}{\eVar}{\embellishedType}{\term}$ & effect definition \\
                 & $\eHandle{\tVar}{\term}{\term}$ & effect handler \\
                 & $\eAnno{\term}{\type}$ & type annotation \\
                 \\


### PR DESCRIPTION
Re-introduce embellished types in the syntax. What do you think?

I also fixed a bug in `T-TApp`.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-t-embellished.pdf) is a link to the PDF generated from this PR.
