### PR TITLE
Use distinct types for term names and type names

### DIFF
--- a/formalization/Name.v
+++ b/formalization/Name.v
@@ -6,5 +6,12 @@
 (*******************************************)
 (*******************************************)
 
-Parameter name : Set.
-Parameter nameEq : forall x1 x2 : name, { x1 = x2 } + { x1 <> x2 }.
+(* Term variables *)
+
+Parameter eName : Set.
+Parameter eNameEq : forall x1 x2 : eName, { x1 = x2 } + { x1 <> x2 }.
+
+(* Type variables *)
+
+Parameter tName : Set.
+Parameter tNameEq : forall x1 x2 : tName, { x1 = x2 } + { x1 <> x2 }.

--- a/formalization/Subrow.v
+++ b/formalization/Subrow.v
@@ -32,7 +32,7 @@ Inductive subrow : row -> row -> Prop :=
 
 Hint Constructors subrow.
 
-Inductive rowContains : row -> name -> Prop :=
+Inductive rowContains : row -> tName -> Prop :=
 | rcSingleton :
   forall a,
   rowContains (rSingleton a) a
@@ -53,7 +53,7 @@ Theorem subrowCorrect :
 Proof.
   split; intros.
   - induction r1; magic.
-    specialize (H n); feed H; magic.
+    specialize (H t). feed H; magic.
     induction r2; inversion H; magic.
   - induction H; inversion H0; magic.
 Qed.

--- a/formalization/Syntax.v
+++ b/formalization/Syntax.v
@@ -11,38 +11,38 @@ Require Import Main.Name.
 (* Terms (e) *)
 
 Inductive term : Type :=
-| eVar : name -> term (* Metavariable: x *)
-| eAbs : name -> type -> row -> term -> term
+| eVar : eName -> term (* Metavariable: x *)
+| eAbs : eName -> type -> row -> term -> term
 | eApp : term -> term -> term
-| eTAbs : name -> term -> term
+| eTAbs : tName -> term -> term
 | eTApp : term -> type -> term
-| eEffect : name -> name -> type -> row -> term -> term
-| eHandle : name -> term -> term -> term
-| eDo : name -> term -> term -> term
+| eEffect : tName -> eName -> type -> row -> term -> term
+| eHandle : tName -> term -> term -> term
+| eDo : eName -> term -> term -> term
 
 (* Proper types (t) *)
 
 with type : Type :=
-| tVar : name -> type (* Metavariable: a *)
+| tVar : tName -> type (* Metavariable: a *)
 | tArrow : type -> row -> type -> row -> type
-| tForAll : name -> type -> row -> type
+| tForAll : tName -> type -> row -> type
 
 (* Rows (r) *)
 
 with row : Type :=
 | rEmpty : row
-| rSingleton : name -> row
+| rSingleton : tName -> row
 | rUnion : row -> row -> row
 
 (* Type contexts (c) *)
 
 with context : Type :=
 | cEmpty : context
-| cTExtend : context -> name -> type -> row -> context
-| cKExtend : context -> name -> context
+| cTExtend : context -> eName -> type -> row -> context
+| cKExtend : context -> tName -> context
 
 (* Effect map (em) *)
 
 with effectMap : Type :=
 | emEmpty : effectMap
-| emExtend : effectMap -> name -> type -> row -> effectMap.
+| emExtend : effectMap -> tName -> type -> row -> effectMap.

--- a/formalization/Tactics.v
+++ b/formalization/Tactics.v
@@ -8,9 +8,8 @@
 
 Require Import Omega.
 
-(* This tactic removes superfluous hypotheses. *)
-
-Ltac clean := repeat (
+(* This is like the `inversion` tactic, but leaves less junk around. *)
+Ltac invert H := inversion H; clear H; repeat (
   match goal with
   | [ H : ?x = ?y |- _ ] => (is_var y; subst x) || (is_var x; subst y)
   | [ H : ?x = ?x |- _ ] => clear H
@@ -23,7 +22,6 @@ Ltac clean := repeat (
 *)
 
 Ltac magic := try abstract (
-  clean;
   cbn;
   intros;
   f_equal;
@@ -42,3 +40,10 @@ Ltac feed H1 := let H2 := fresh "H" in
   match type of H1 with
   | ?T -> _ => assert (H2 : T); [ | specialize (H1 H2); clear H2 ]
   end.
+
+(*
+  This tactic takes a given term and adds its type to the context as a new
+  hypothesis.
+*)
+
+Ltac fact E := let H := fresh "H" in pose (H := E); clearbody H.


### PR DESCRIPTION
Use distinct types for term names and type names. I also updated the tactics library based on my experience in https://github.com/stepchowfun/coq-fun.