### PR TITLE
Fail if 'Admitted' is found in proofs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,16 @@ formalization:
 	rm -f _CoqProjectFull Makefile.coq Makefile.coq.conf
 
 lint-formalization: formalization
+	if grep \
+	  --recursive \
+	  --line-number \
+	  --include '*.v' \
+	  Admitted \
+	  formalization; \
+	then \
+	  echo "Error: 'Admitted' found in proofs." 1>&2; \
+	  exit 1; \
+	fi
 	./scripts/lint-imports.rb \
 	  '^\s*Require ' \
 	  'coqc -R formalization Main ?' \


### PR DESCRIPTION
Fail if `Admitted` is found in proofs. Too extreme?

This is what it looks like when it fails:

<img width="535" alt="screenshot 2018-03-18 16 27 19" src="https://user-images.githubusercontent.com/796574/37572506-412cc724-2ac9-11e8-9917-4a1388631d6c.png">
