### PR TITLE
Remove references to a nonexistent '.github' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ formalization/**/*.aux
 formalization/**/*.glob
 formalization/**/*.v.d
 formalization/**/*.vo
-formalization/**/*.vo.aux
 implementation/.stack-work/*
 main.pdf

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,7 @@ lint: lint-paper lint-formalization lint-implementation
 	./scripts/lint-general.rb $(shell \
 	  find . -type d \( \
 	    -path ./.git -o \
-	    -path ./.github -o \
 	    -path ./.paper-build -o \
-	    -path ./.stack -o \
 	    -path ./implementation/.stack-work \
 	  \) -prune -o \( \
 	    -name '*.hs' -o \
@@ -48,9 +46,7 @@ lint-paper:
 	./scripts/lint-tex.rb $(shell \
 	  find . -type d \( \
 	    -path ./.git -o \
-	    -path ./.github -o \
 	    -path ./.paper-build -o \
-	    -path ./.stack -o \
 	    -path ./implementation/.stack-work \
 	  \) -prune -o -name '*.tex' -print \
 	)
@@ -75,9 +71,7 @@ lint-formalization: formalization
 	  $(shell \
 	    find . -type d \( \
 	      -path ./.git -o \
-	      -path ./.github -o \
 	      -path ./.paper-build -o \
-	      -path ./.stack -o \
 	      -path ./implementation/.stack-work \
 	    \) -prune -o \( \
 	      -name '*.v' \
@@ -89,9 +83,7 @@ lint-formalization: formalization
 	  $(shell \
 	    find . -type d \( \
 	      -path ./.git -o \
-	      -path ./.github -o \
 	      -path ./.paper-build -o \
-	      -path ./.stack -o \
 	      -path ./implementation/.stack-work \
 	    \) -prune -o \( \
 	      -name '*.v' \
@@ -112,9 +104,7 @@ clean-formalization:
 	rm -f _CoqProjectFull Makefile.coq $(shell \
 	  find . -type d \( \
 	    -path ./.git -o \
-	    -path ./.github -o \
 	    -path ./.paper-build -o \
-	    -path ./.stack -o \
 	    -path ./implementation/.stack-work \
 	  \) -prune -o \( \
 	    -name '*.aux' -o \
@@ -138,9 +128,7 @@ lint-implementation:
 	for file in $(shell \
 	  find . -type d \( \
 	    -path ./.git -o \
-	    -path ./.github -o \
 	    -path ./.paper-build -o \
-	    -path ./.stack -o \
 	    -path ./implementation/.stack-work \
 	  \) -prune -o \( \
 	    -name '*.hs' \
@@ -155,9 +143,7 @@ format-implementation:
 	for file in $(shell \
 	  find . -type d \( \
 	    -path ./.git -o \
-	    -path ./.github -o \
 	    -path ./.paper-build -o \
-	    -path ./.stack -o \
 	    -path ./implementation/.stack-work \
 	  \) -prune -o \( \
 	    -name '*.hs' \

--- a/implementation/LICENSE
+++ b/implementation/LICENSE
@@ -1,4 +1,4 @@
-Copyright Stephan Boyer and Esther Wang (c) 2017
+Copyright Stephan Boyer and Esther Wang (c) 2018
 
 All rights reserved.
 

--- a/implementation/implementation.cabal
+++ b/implementation/implementation.cabal
@@ -7,7 +7,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Stephan Boyer and Esther Wang
 maintainer:          stephan@stephanboyer.com and esther.wang47@gmail.com
-copyright:           (c) 2017 Stephan Boyer and Esther Wang
+copyright:           (c) 2018 Stephan Boyer and Esther Wang
 category:            Web
 build-type:          Simple
 extra-source-files:  README.md


### PR DESCRIPTION
Remove references to a nonexistent `.github` directory. We used to have a pull request template in there to instruct us how to link to the PDF from the branch build, but these days the deploy script automatically posts a link to that PDF in pull requests.

I also removed some other `.gitignore` paths (and analogous paths in the Makefile) that I believe are not used.

I updated the copyright years too.