### PR TITLE
Use a less ambiguous example

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -100,7 +100,7 @@
 
 \lstdefinelanguage{gram}{
   comment=[l]{\#},
-  morekeywords={reify, reflect, as, in, data, let},
+  morekeywords={reify, reflect, as, in, data, let, where},
 }
 
 \ifnoacm

--- a/paper/overview.tex
+++ b/paper/overview.tex
@@ -7,9 +7,8 @@
     \noindent
     \begin{minipage}{\linewidth}
       \begin{lstlisting}[gobble=8, mathescape=true]
-        reify "Hello" as a in
-          x $\leftarrow$ reflect a in
-            x + ", World!"
+        reify 4 as a in
+          3 + reflect a
       \end{lstlisting}
     \end{minipage}
 
@@ -30,12 +29,12 @@
     \begin{minipage}{\linewidth}
       \begin{lstlisting}[gobble=8, mathescape=true]
         identity : <Monoid a> $\Rightarrow$ a
-        identity = $\lambda$(a : *) (b : <Monoid a>) $\rightarrow$
-          let Monoid x _ = reflect b in x
+        identity = $\lambda$(a : *) (b : <Monoid a>) . x
+          where Monoid x _ = reflect b
 
         combine : <Monoid a> $\Rightarrow$ a $\rightarrow$ a $\rightarrow$ a
-        combine = $\lambda$(a : *) (b : <Monoid a>) $\rightarrow$
-          let Monoid _ x = reflect b in x
+        combine = $\lambda$(a : *) (b : <Monoid a>) . x
+          where Monoid _ x = reflect b
       \end{lstlisting}
     \end{minipage}
 


### PR DESCRIPTION
Use a less ambiguous example in the introduction. String concatenation is `+` in some languages and `++` in others, but integer addition is almost always `+`. I also removed a bind, because I'm not sure why it was there in the first place.

@esdrw 