### PR TITLE
Simplify the syntactic sugar

### DIFF
--- a/paper/overview.tex
+++ b/paper/overview.tex
@@ -28,11 +28,11 @@
     \noindent
     \begin{minipage}{\linewidth}
       \begin{lstlisting}[gobble=8, mathescape=true]
-        identity : <Monoid a> $\Rightarrow$ a
+        identity : Monoid a $\Rightarrow$ a
         identity = $\lambda$(a : *) (b : <Monoid a>) . x
           where Monoid x _ = reflect b
 
-        combine : <Monoid a> $\Rightarrow$ a $\rightarrow$ a $\rightarrow$ a
+        combine : Monoid a $\Rightarrow$ a $\rightarrow$ a $\rightarrow$ a
         combine = $\lambda$(a : *) (b : <Monoid a>) . x
           where Monoid _ x = reflect b
       \end{lstlisting}


### PR DESCRIPTION
Previously, we had the following syntactic sugar for types:

> `K => T` means `forall t : K, T` where `t` does not occur in `T`.

But after thinking about it for a while, I think the only time you would ever quantify over a type and not use it (at the type level) is when that type is a witness (e.g., a type class instance or effect handler). For example:

    <Monoid a> => a -> a -> a

So, I propose the following slightly more streamlined sugar instead:

> `T1 => T2` means `forall t : <T1> . T2` where `t` does not occur in `T2`.

Then the monoid example becomes:

    Monoid a => a -> a -> a

The only difference is the lack of angle brackets `<>`.

@esdrw 