### PR TITLE
Don't show the date for non-acm builds and default to acm in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ docker-build:
 	      chown -R user:user repo && \
 	      cd repo && \
 	      su user -s /bin/bash -l -c " \
-	        cd repo && make clean && make all test lint \
+	        cd repo && make clean && make all test lint USEACM=true \
 	      " && (test "$$DEPLOY" != true || ./scripts/deploy.rb) \
 	    ' \
 	)" && \

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -38,8 +38,13 @@
 
 \title{Reflection and entanglement}
 
+\ifnoacm
+  \date{}
+\fi
+
+\author{Stephan Boyer}
+
 \ifacm
-  \author{Stephan Boyer}
   \orcid{0000-0003-4599-2683}
   \affiliation{%
     \institution{Airbnb, Inc.}


### PR DESCRIPTION
Don't show the date for non-acm builds and default to acm in CI. This basically means local work is in distraction-free mode, but the paper that is deployed in CI includes all the metadata.