### PR TITLE
Change T-Reflect to return an entangled type

### DIFF
--- a/paper/entanglement.tex
+++ b/paper/entanglement.tex
@@ -97,7 +97,7 @@
       \begin{prooftree}
           \AxiomC{$\hasKind{\context}{\tVar}{\kWitness{\type}}$}
         \RightLabel{(\textsc{T-Reflect})}
-        \UnaryInfC{$\hasType{\context}{\eReflect{\tVar}}{\type}$}
+        \UnaryInfC{$\hasType{\context}{\eReflect{\tVar}}{\tEntangled{\type}{\tSingleton{\tVar}}}$}
       \end{prooftree}
 
       \begin{prooftree}


### PR DESCRIPTION
Change `T-Reflect` to return an entangled type. Unfortunately this is needed to make effect tracking work; without it, you could reflect an `IO` instance into a term, pass it to some distant part of the program, and reflect it back as a type variable to allow IO wherever you want.

@esdrw 