### PR TITLE
Delete the idea of singleton rows

### DIFF
--- a/paper/calculus.tex
+++ b/paper/calculus.tex
@@ -25,7 +25,6 @@
           & $\tForAll{\tVar}{\kind}{\type}$ & universal type \\
           & $\tComputation{\type}{\row}$ & computation type \\
           & $\tEmpty$ & empty row \\
-          & $\tSingleton{\tVar}$ & singleton row \\
           & $\tUnion{\row}{\row}$ & row union \\
           \\
           $\kind \Coloneqq$ & & kinds: \\
@@ -172,12 +171,6 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hasKind{\context}{\tVar}{\kWitness{\type}}$}
-        \RightLabel{(\textsc{K-Singleton})}
-        \UnaryInfC{$\hasKind{\context}{\tSingleton{\tVar}}{\kRow}$}
-      \end{prooftree}
-
-      \begin{prooftree}
           \AxiomC{$\hasKind{\context}{\row_1}{\kRow}$}
           \AxiomC{$\hasKind{\context}{\row_2}{\kRow}$}
         \RightLabel{(\textsc{K-Union})}
@@ -196,9 +189,9 @@
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\hasKind{\context}{\row}{\kRow}$}
-        \RightLabel{(\textsc{R-Refl})}
-        \UnaryInfC{$\rowSub{\context}{\row}{\row}$}
+          \AxiomC{$\hasKind{\context}{\tVar}{\kRow}$}
+        \RightLabel{(\textsc{R-Var})}
+        \UnaryInfC{$\rowSub{\context}{\tVar}{\tVar}$}
       \end{prooftree}
 
       \begin{prooftree}
@@ -455,11 +448,6 @@
           \AxiomC{}
         \RightLabel{(\textsc{S-Empty})}
         \UnaryInfC{$\translatesTo{\context}{\tEmpty}{\tUnit}$}
-        \DisplayProof
-        \qquad
-          \AxiomC{}
-        \RightLabel{(\textsc{S-Singleton})}
-        \UnaryInfC{$\translatesTo{\context}{\tSingleton{\tVar}}{\tUnit}$}
         \DisplayProof
         \qquad
           \AxiomC{}

--- a/paper/macros.tex
+++ b/paper/macros.tex
@@ -30,7 +30,6 @@
 \newcommand\tComputation[2]{#1 \; ! \; #2}
 \newcommand\row{\varepsilon}
 \newcommand\tEmpty{\varnothing}
-\newcommand\tSingleton[1]{\left\{ #1 \right\}}
 \newcommand\tUnion[2]{#1 \cup #2}
 \newcommand\tVoid{\mathbf{0}}
 \newcommand\tUnit{\mathbf{1}}


### PR DESCRIPTION
I feel like I hit a stroke of good luck this weekend. Another opportunity for simplification has presented itself: apparently we don't need singleton rows.

To recap, we previously had 4 things that can have the kind `row`:

- A type variable which stands for an unknown row
- The empty row
- The singleton row containing a single type variable of kind `witness`
- The union of two rows

Some recent developments have made singleton rows completely obsolete: rows are now fully abstract, with no internal structure. Note that:

- Type classes don't use rows at all
- Effects are polymorphic over entire rows and never refer to singletons:

   ```haskell
   data IO e = IO (String ! e) (String -> () ! e)
   ```

Therefore, we should not even have singleton rows. We are left with:

- A type variable which stands for an unknown row
- The empty row
- The union of two rows

Exciting times! The system keeps getting simpler—although I suspect this is about as simple as it will get.

@esdrw 