### PR TITLE
Delete the concept of row union

### DIFF
--- a/paper/calculus.tex
+++ b/paper/calculus.tex
@@ -24,8 +24,7 @@
           & $\tArrow{\type}{\type}$ & arrow type \\
           & $\tForAll{\tVar}{\kind}{\type}$ & universal type \\
           & $\tComputation{\type}{\row}$ & computation type \\
-          & $\tEmpty$ & empty row \\
-          & $\tUnion{\row}{\row}$ & row union \\
+          & $\tPure$ & pure row \\
           \\
           $\kind \Coloneqq$ & & kinds: \\
           & $\kType$ & kind of proper types \\
@@ -111,20 +110,13 @@
       \begin{prooftree}
           \AxiomC{$\hasType{\context}{\term}{\type}$}
         \RightLabel{(\textsc{T-Pure})}
-        \UnaryInfC{$\hasType{\context}{\ePure{\term}}{\tComputation{\type}{\tEmpty}}$}
+        \UnaryInfC{$\hasType{\context}{\ePure{\term}}{\tComputation{\type}{\tPure}}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hasType{\context}{\term}{\tComputation{\type}{\tEmpty}}$}
+          \AxiomC{$\hasType{\context}{\term}{\tComputation{\type}{\tPure}}$}
         \RightLabel{(\textsc{T-Run})}
         \UnaryInfC{$\hasType{\context}{\eRun{\term}}{\type}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\hasType{\context}{\term}{\tComputation{\type}{\row_1}}$}
-          \AxiomC{$\rowSub{\context}{\row_1}{\row_2}$}
-        \RightLabel{(\textsc{T-Subsumption})}
-        \BinaryInfC{$\hasType{\context}{\term}{\tComputation{\type}{\row_2}}$}
       \end{prooftree}
 
       \caption{Typing rules}
@@ -166,63 +158,12 @@
 
       \begin{prooftree}
           \AxiomC{}
-        \RightLabel{(\textsc{K-Empty})}
-        \UnaryInfC{$\hasKind{\context}{\tEmpty}{\kRow}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\hasKind{\context}{\row_1}{\kRow}$}
-          \AxiomC{$\hasKind{\context}{\row_2}{\kRow}$}
-        \RightLabel{(\textsc{K-Union})}
-        \BinaryInfC{$\hasKind{\context}{\tUnion{\row_1}{\row_2}}{\kRow}$}
+        \RightLabel{(\textsc{K-Pure})}
+        \UnaryInfC{$\hasKind{\context}{\tPure}{\kRow}$}
       \end{prooftree}
 
       \caption{Kinding rules}
       \label{fig:kinding}
-    \end{figure}
-
-    \begin{figure}[H]
-      \begin{center}
-        \framebox{$\rowSub{\context}{\row}{\row}$}
-      \end{center}
-
-      \medskip
-
-      \begin{prooftree}
-          \AxiomC{$\hasKind{\context}{\tVar}{\kRow}$}
-        \RightLabel{(\textsc{R-Var})}
-        \UnaryInfC{$\rowSub{\context}{\tVar}{\tVar}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\hasKind{\context}{\row}{\kRow}$}
-        \RightLabel{(\textsc{R-Empty})}
-        \UnaryInfC{$\rowSub{\context}{\tEmpty}{\row}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\rowSub{\context}{\row_1}{\row_2}$}
-          \AxiomC{$\hasKind{\context}{\row_3}{\kRow}$}
-        \RightLabel{(\textsc{R-Weakening1})}
-        \BinaryInfC{$\rowSub{\context}{\row_1}{\tUnion{\row_2}{\row_3}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\rowSub{\context}{\row_1}{\row_3}$}
-          \AxiomC{$\hasKind{\context}{\row_2}{\kRow}$}
-        \RightLabel{(\textsc{R-Weakening2})}
-        \BinaryInfC{$\rowSub{\context}{\row_1}{\tUnion{\row_2}{\row_3}}$}
-      \end{prooftree}
-
-      \begin{prooftree}
-          \AxiomC{$\rowSub{\context}{\row_1}{\row_3}$}
-          \AxiomC{$\rowSub{\context}{\row_2}{\row_3}$}
-        \RightLabel{(\textsc{R-Strengthening})}
-        \BinaryInfC{$\rowSub{\context}{\tUnion{\row_1}{\row_2}}{\row_3}$}
-      \end{prooftree}
-
-      \caption{Row subsumption}
-      \label{fig:row_subsumption}
     \end{figure}
 
   \subsection{Semantics}
@@ -438,21 +379,15 @@
         \DisplayProof
       \end{center}
 
-      \begin{prooftree}
+      \begin{center}
           \AxiomC{$\translatesTo{\context}{\type_1}{\type_2}$}
         \RightLabel{(\textsc{S-Computation})}
         \UnaryInfC{$\translatesTo{\context}{\tComputation{\type_1}{\row}}{\tArrow{\tUnit}{\type_2}}$}
-      \end{prooftree}
-
-      \begin{center}
-          \AxiomC{}
-        \RightLabel{(\textsc{S-Empty})}
-        \UnaryInfC{$\translatesTo{\context}{\tEmpty}{\tUnit}$}
         \DisplayProof
         \qquad
           \AxiomC{}
-        \RightLabel{(\textsc{S-Union})}
-        \UnaryInfC{$\translatesTo{\context}{\tUnion{\row_1}{\row_2}}{\tUnit}$}
+        \RightLabel{(\textsc{S-Pure})}
+        \UnaryInfC{$\translatesTo{\context}{\tPure}{\tUnit}$}
         \DisplayProof
       \end{center}
 

--- a/paper/macros.tex
+++ b/paper/macros.tex
@@ -29,8 +29,7 @@
 \newcommand\tForAllNoKind[2]{\forall #1 \; . \; #2}
 \newcommand\tComputation[2]{#1 \; ! \; #2}
 \newcommand\row{\varepsilon}
-\newcommand\tEmpty{\varnothing}
-\newcommand\tUnion[2]{#1 \cup #2}
+\newcommand\tPure{\varnothing}
 \newcommand\tVoid{\mathbf{0}}
 \newcommand\tUnit{\mathbf{1}}
 
@@ -49,7 +48,6 @@
 % Judgments
 \newcommand\hasType[3]{#1 \vdash \tAnno{#2}{#3}}
 \newcommand\hasKind[3]{#1 \vdash \kAnno{#2}{#3}}
-\newcommand\rowSub[3]{#1 \vdash #2 \subseteq #3}
 \newcommand\translatesTo[3]{#1 \vdash #2 \rightsquigarrow #3}
 
 % Pseudo-constructs used for exposition


### PR DESCRIPTION
I took a 30m nap after merging https://github.com/stepchowfun/delimited-effects/pull/377 and then woke up to realize: we don't even need row union! So we used to have this:

```haskell
computation : forall (i1 : <IO e1>) (i2 : <Exception e2>) . Int ! e1 U e2
```

But I realized we can actually just have `IO` and `Exception` be instantiated to the same effect row `e`:

```haskell
computation : forall (i1 : <IO e>) (i2 : <Exception e>) . Int ! e
```

So, let's delete union! Now there are exactly two things which can be given kind `row`:

- A type variable standing for an unknown row
- The empty row

In fact, we probably shouldn't even call them "rows" anymore. I'll figure out a better name in a follow-up PR.

I deleted the entire "row subsumption" figure. Also, I deleted `T-Subsumption`, which means our system is now 100% syntax-directed. So much stuff deleted this weekend!

@esdrw 